### PR TITLE
Mink in env

### DIFF
--- a/src/Behat/Mink/Integration/MinkEnvironment.php
+++ b/src/Behat/Mink/Integration/MinkEnvironment.php
@@ -53,6 +53,10 @@ class MinkEnvironment extends Environment
     {
         static $mink;
 
+        if (isset($this->mink)) {
+            $mink = $this->mink;
+        }
+
         if (null === $mink) {
             $mink = new Mink();
             $this->registerMinkSessions($mink);


### PR DESCRIPTION
I am not using the bundled `$mink` and have it defined in `env.php` as I want to provide my own Sahi's SID. There might be a better way but I surely do not know.

I think Mink shall prevent itself from instantiating a new one if it's already defined in `env.php`. Thoughts?
