### PR TITLE
Made steps "I should see", "I should not see" work regardless of tags

### DIFF
--- a/src/Behat/Mink/Integration/steps/mink_steps.php
+++ b/src/Behat/Mink/Integration/steps/mink_steps.php
@@ -58,11 +58,11 @@ $steps->When('/^(?:|I )attach the file "(?P<path>[^"]*)" to "(?P<field>[^"]*)"$/
 });
 
 $steps->Then('/^(?:|I )should see "(?P<text>[^"]*)"$/', function($world, $text) {
-    assertRegExp('/'.preg_quote($text, '/').'/', $world->getSession()->getPage()->getContent());
+    assertRegExp('/'.preg_quote($text, '/').'/', strip_tags($world->getSession()->getPage()->getContent()));
 });
 
 $steps->Then('/^(?:|I )should not see "(?P<text>[^"]*)"$/', function($world, $text) {
-    assertNotRegExp('/'.preg_quote($text, '/').'/', $world->getSession()->getPage()->getContent());
+    assertNotRegExp('/'.preg_quote($text, '/').'/', strip_tags($world->getSession()->getPage()->getContent()));
 });
 
 $steps->Then('/^the "(?P<field>[^"]*)" field should contain "(?P<value>[^"]*)"$/', function($world, $field, $value) {


### PR DESCRIPTION
Hello!

It seems that content retrieved from page has tags included. However, since Behat is a human-friendly framework, I thought that "I should see" step must mean explicitly "What a user would see on the page in a browser", without any tags. So, I've wrapped the page content in a strip_tags call.

P.S. This is my first pull request, hope I've done everything right.
