### PR TITLE
Removed code to automatically start sessions

### DIFF
--- a/src/Behat/Mink/Mink.php
+++ b/src/Behat/Mink/Mink.php
@@ -115,12 +115,6 @@ class Mink
 
         $session = $this->sessions[$name];
 
-        // start session if needed
-        if (!$session->isStarted()) {
-            $session->start();
-            $this->defaultSessionName = $name;
-        }
-
         return $session;
     }
 


### PR DESCRIPTION
During my experiments, the removed lines created 4 requests to the server (/ then /login and again /, /login). In addition, they prevented my app to set correctly the default language (during these 4 requests, no preferred language headers were sent).

As far as I know, removing these lines didn't seem to break something…
