### PR TITLE
Make Mink non-static

### DIFF
--- a/src/Behat/Mink/Behat/Context/MinkContext.php
+++ b/src/Behat/Mink/Behat/Context/MinkContext.php
@@ -41,7 +41,7 @@ require_once 'PHPUnit/Framework/Assert/Functions.php';
  */
 class MinkContext extends BehatContext implements TranslatedContextInterface
 {
-    private static $minkInstance;
+    private $minkInstance;
     private $parameters;
 
     /**
@@ -67,10 +67,8 @@ class MinkContext extends BehatContext implements TranslatedContextInterface
             )
         ), $parameters);
 
-        if (null === self::$minkInstance) {
-            self::$minkInstance = new Mink();
-            $this->registerSessions(self::$minkInstance);
-        }
+        $this->minkInstance = new Mink();
+        $this->registerSessions($this->minkInstance);
     }
 
     /**
@@ -94,13 +92,13 @@ class MinkContext extends BehatContext implements TranslatedContextInterface
      */
     public function getMink()
     {
-        if (null === self::$minkInstance) {
+        if (null === $this->minkInstance) {
             throw new \RuntimeException(
                 'Mink is not initialized. Forgot to call parent context constructor?'
             );
         }
 
-        return self::$minkInstance;
+        return $this->minkInstance;
     }
 
     /**


### PR DESCRIPTION
This patch makes the Mink instance non static, and creates a new instance for each FeatureContext.

The reasoning behind this is to create fresh sessions for each FeatureContext instance. Right now, sessions seem to be shared across scenarios (like if I login in the first Scenario, them I'm still logged in in the second scenario).
