### PR TITLE
Fix accessing and verifying pages outside of base_url.

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -105,7 +105,7 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     {
         $startUrl = rtrim($this->getParameter('base_url'), '/') . '/';
 
-        return 0 !== strpos('http', $path) ? $startUrl . ltrim($path, '/') : $path;
+        return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
     }
 
     /**


### PR DESCRIPTION
The parameter order of strpos was backwords. This prevents accessing and verifying pages outside of the base_url.
