### PR TITLE
Add new add fill field with params definition

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -183,6 +183,20 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
         $value = str_replace('\\"', '"', $value);
         $this->getSession()->getPage()->fillField($field, $value);
     }
+    
+    /**
+     * Fills in form field with specified id|name|label|value using predefined param.
+     * param value comes from behat.yml context parameters.
+     *
+     * @When /^(?:|I )fill in "(?P<field>(?:[^"]|\\")*)" with param "(?P<name>(?:[^"]|\\")*)"$/
+     * @When /^(?:|I )fill in param "(?P<name>(?:[^"]|\\")*)" for "(?P<field>(?:[^"]|\\")*)"$/
+     */
+    public function fillField($field, $name)
+    {
+        $field = str_replace('\\"', '"', $field);
+        $value = str_replace('\\"', '"', $this->getParameter($name));
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
 
     /**
      * Fills in form fields with provided table.


### PR DESCRIPTION
Added a definition to fill field not with a given value, but a given param name.
The param value comes from behat.yml context parameters vie getParameters().
You don't have to modify your features anymore when changing a parameters used in your features.
