### PR TITLE
Correction of an issue with big DOM and pcre limit

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -215,8 +215,8 @@ class SahiDriver implements DriverInterface
         $html = $this->evaluateScript('document.getElementsByTagName("html")[0].innerHTML');
 
         $html = preg_replace(array(
-            '/<\!--SAHI_INJECT_START--\>.*\<\!--SAHI_INJECT_END--\>/s',
-            '/\<script\>\/\*\<\!\[CDATA\[\*\/\/\*----\>\*\/__sahi.*\<\!--SAHI_INJECT_END--\>/s'
+            '/<\!--SAHI_INJECT_START--\>.*\<\!--SAHI_INJECT_END--\>/sU',
+            '/\<script\>\/\*\<\!\[CDATA\[\*\/\/\*----\>\*\/__sahi.*\<\!--SAHI_INJECT_END--\>/sU'
         ), '', $html);
         $html = html_entity_decode($html);
 


### PR DESCRIPTION
Hello,

We were having some issues while testing a big web application with Sahi. On some very large page (2000 lines of DOM), the Sahi driver was unable to read the DOM (or doing anything with it).

I found that the preg_replace is not working and preg_last_error is returning PREG_BACKTRACK_LIMIT_ERROR, it was a bit unexpected because I don't find the expression complex, nor the code that big, but adding the ungreedy flag helped (I did not want to raise the pcre.backtrack_limit). I think it is sufficient to go for ungreedy in this specific case.

You can find more details on the issue here : http://team-fusion.pmsipilot.com/?p=308 (written in French)

Cheers,

Gabriel
