### PR TITLE
Escape show cmd argument

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -611,7 +611,7 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
 
         $filename = rtrim($this->getParameter('show_tmp_dir'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.uniqid().'.html';
         file_put_contents($filename, $this->getSession()->getPage()->getContent());
-        system(sprintf($this->getParameter('show_cmd'), $filename));
+        system(sprintf($this->getParameter('show_cmd'), escapeshellarg($filename)));
     }
 
     /**


### PR DESCRIPTION
Resend of PR #101:

Hi there, in `BaseMinkContext::showLastResponse()` the path of the temporary file is passed to system() unescaped. If `show_tmp_dir` has any special characters in it (such as a space), this can cause unexpected results (in the case of white space, the path will be interpreted as multiple arguments).

This patch uses escapeshellarg() to escape and quote the path.
