### PR TITLE
Fix the JavascriptDriverTest

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -10,9 +10,9 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
     {
         $this->getSession()->visit($this->pathTo('/aria_roles.php'));
 
-        $this->getSession()->wait(5000, '$("#toggle-element").is(":visible") === false');
+        $this->getSession()->wait(5000, '$("#hidden-element").is(":visible") === false');
         $this->getSession()->getPage()->pressButton('Toggle');
-        $this->getSession()->wait(5000, '$("#toggle-element").is(":visible") === true');
+        $this->getSession()->wait(5000, '$("#hidden-element").is(":visible") === true');
 
         $this->getSession()->getPage()->clickLink('Go to Index');
         $this->assertEquals($this->pathTo('/index.php'), $this->getSession()->getCurrentUrl());


### PR DESCRIPTION
According to the web-fixtures/aria_roles.php file, the CSS selectors in
the tests are not correctly defined
