### PR TITLE
Don't prepend an asterisk to the browser setup command sent to Selenium

### DIFF
--- a/src/Behat/Mink/Driver/SeleniumDriver.php
+++ b/src/Behat/Mink/Driver/SeleniumDriver.php
@@ -68,7 +68,7 @@ class SeleniumDriver implements DriverInterface
      */
     public function __construct($browser, $baseUrl, SeleniumClient $client)
     {
-        $this->browser = $client->getBrowser($baseUrl, '*'.$browser);
+        $this->browser = $client->getBrowser($baseUrl, $browser);
     }
 
     /**


### PR DESCRIPTION
Using the Selenium driver to control a remote browser, hosted on https://saucelabs.com/, requires passing a snippet of JSON as the browser setup command to the remote server which contains the Saucelabs username, API key, requested browser and OS version, etc. This can be done by placing the snippet in behat.yml, for example:

```
default:
  context:
    parameters:
      default_session: goutte
      javascript_session: selenium
      base_url: http://website.under.test/
      browser: '{ "username": "saucelabs",
        "access-key": "xxxx-xxxx-xxxx-xxxx",
        "browser": "firefox",
        "browser-version": "7", 
        "os": "Windows 2003",
        "name": "Testing Selenium with Behat" }'
      selenium:
        host: ondemand.saucelabs.com
        port: 80
```

...however the SeleniumDriver in Mink seems to assume that the "browser" parameter is always going to be a simple string with the browser name, and always prepends a '*' to it before sending it to the Selenium server, which is incorrect in this case (it sends *{ "username": ... which is invalid JSON)
