### PR TITLE
Fixed call to a member function getSession() on a non-object

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -588,10 +588,10 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
      */
     public function assertNumElements($num, $element)
     {
-        $nodes = $world->getSession()->getPage()->findAll('css', $element);
+        $nodes = $this->getSession()->getPage()->findAll('css', $element);
 
         if (null === $nodes) {
-            throw new ElementNotFoundException($world->getSession(), 'element: '.$element.' ');
+            throw new ElementNotFoundException($this->getSession(), 'element: '.$element.' ');
         }
 
         assertSame((int) $num, count($nodes));


### PR DESCRIPTION
Fixed call to a member function getSession() on a non-object 

($world instead of $this)
