### PR TITLE
Fixed assertNumElements method on BaseMinkContext

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -588,13 +588,18 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
      */
     public function assertNumElements($num, $element)
     {
-        $nodes = $world->getSession()->getPage()->findAll('css', $element);
+        $nodes = $this->getSession()->getPage()->findAll('css', $element);
 
         if (null === $nodes) {
-            throw new ElementNotFoundException($world->getSession(), 'element: '.$element.' ');
+            throw new ElementNotFoundException($this->getSession(), 'element: '.$element.' ');
         }
 
-        assertSame((int) $num, count($nodes));
+        try {
+            assertEquals((int) $num, count($nodes));
+        } catch (AssertException $e) {
+            $message = sprintf('%s elements matching css "%s" appears on this page, but it should be %s.', count($nodes), $element, (int) $num);
+            throw new ExpectationException($message, $this->getSession(), $e);
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

I encountered some issues using the statement "Then I Should see <num> <element> elements" and after reading code, I found 2 problems in assertNumElements() method:
- a typo with `$world` var that does not exists
- assert is not on a try/catch and do not throw ExpectationException

Tell me if this pull request solves the problem and if it can be included in Mink.

++
