### PR TITLE
Groups for drivers Testssuites

### DIFF
--- a/tests/Behat/Mink/Driver/GoutteDriverTest.php
+++ b/tests/Behat/Mink/Driver/GoutteDriverTest.php
@@ -4,6 +4,9 @@ namespace Tests\Behat\Mink\Driver;
 
 require_once 'HeadlessDriverTest.php';
 
+/**
+ * @group gouttedriver
+ */
 class GoutteDriverTest extends HeadlessDriverTest
 {
     protected function setUp()

--- a/tests/Behat/Mink/Driver/SahiDriverTest.php
+++ b/tests/Behat/Mink/Driver/SahiDriverTest.php
@@ -6,6 +6,9 @@ use Behat\Mink\Mink;
 
 require_once 'JavascriptDriverTest.php';
 
+/**
+ * @group sahidriver
+ */
 class SahiDriverTest extends JavascriptDriverTest
 {
     protected static function registerMinkSessions(Mink $mink)

--- a/tests/Behat/Mink/Driver/SeleniumDriverTest.php
+++ b/tests/Behat/Mink/Driver/SeleniumDriverTest.php
@@ -4,6 +4,9 @@ namespace Tests\Behat\Mink\Driver;
 
 require_once 'JavascriptDriverTest.php';
 
+/**
+ * @group seleniumdriver
+ */
 class SeleniumDriverTest extends JavascriptDriverTest
 {
     protected function setUp()

--- a/tests/Behat/Mink/Driver/ZombieDriverTest.php
+++ b/tests/Behat/Mink/Driver/ZombieDriverTest.php
@@ -4,6 +4,9 @@ namespace Tests\Behat\Mink\Driver;
 
 require_once 'JavascriptDriverTest.php';
 
+/**
+ * @group zombiedriver
+ */
 class ZombieDriverTest extends JavascriptDriverTest
 {
     protected function setUp()


### PR DESCRIPTION
Allows for running unittests only for a specific driver using --group with phpunit:

```
$ phpunit --group gouttedriver
```

or

```
$ phpunit --group sahidriver
```

Especially usefull if you don't have setup zombiejs, sahi or selenium.
