### PR TITLE
Allow "url" to be case-insensitive in step "the url should match"

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -277,7 +277,7 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     /**
      * Checks, that current page PATH matches regular expression.
      *
-     * @Then /^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/
+     * @Then /^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/
      */
     public function assertUrlRegExp($pattern)
     {


### PR DESCRIPTION
Some people like to refer to the URL acronym in all upper-case. This PR allows this step to run no matter the casing of URL used.
