### PR TITLE
Gh 169 Added 2 new steps to verify that text matching specified pattern appears or not appears on a page

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -362,6 +362,40 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     }
 
     /**
+     * Checks, that page contains text matching specified pattern.
+     *
+     * @Then /^(?:|I )should see text matching (?P<pattern>"(?:[^"]|\\")*")$/
+     */
+    public function assertPageMatchesText($pattern)
+    {
+        $actual = $this->getSession()->getPage()->getText();
+
+        try {
+            assertRegExp($pattern, $actual);
+        } catch (AssertException $e) {
+            $message = sprintf('The pattern %s was not found anywhere in the text of the current page.', $pattern);
+            throw new ResponseTextException($message, $this->getSession(), $e);
+        }
+    }
+
+    /**
+     * Checks, that page doesn't contain text matching specified pattern.
+     *
+     * @Then /^(?:|I )should not see text matching (?P<pattern>"(?:[^"]|\\")*")$/
+     */
+    public function assertPageNotMatchesText($pattern)
+    {
+        $actual = $this->getSession()->getPage()->getText();
+
+        try {
+            assertNotRegExp($pattern, $actual);
+        } catch (AssertException $e) {
+            $message = sprintf('The pattern %s was found in the text of the current page, but it should not.', $pattern);
+            throw new ResponseTextException($message, $this->getSession(), $e);
+        }
+    }
+
+    /**
      * Checks, that HTML response contains specified string.
      *
      * @Then /^the response should contain "(?P<text>(?:[^"]|\\")*)"$/


### PR DESCRIPTION
As discussed on https://github.com/Behat/Mink/pull/170 - 2 new steps with the definitions like this:
- I should see text matching /ensure that you have at least PHP 5.3.\d installed/
- I should not see text matching /ensure that you have at least PHP 5.2.\d installed/

I hope it's better now ;)
