### PR TITLE
Modify assertUrlRegExp to only accept matching regexp pattern

### DIFF
--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -277,17 +277,10 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     /**
      * Checks, that current page PATH matches regular expression.
      *
-     * @Then /^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/
+     * @Then /^the (?i)url(?-i) should match (?P<pattern>\/([^\/]|\\\/)*\/)$/
      */
     public function assertUrlRegExp($pattern)
     {
-        $pattern = str_replace('\\"', '"', $pattern);
-        if (!preg_match('/^\/.*\/$/', $pattern)) {
-            $this->assertPageAddress($pattern);
-
-            return;
-        }
-
         $actual = parse_url($this->getSession()->getCurrentUrl(), PHP_URL_PATH);
 
         try {


### PR DESCRIPTION
As discussed on https://github.com/Behat/Mink/pull/170 and on https://github.com/Behat/Mink/pull/173
