### PR TITLE
[Selenium Driver] When multiple radio/checkbox elements found with the same name selectOption() checks only the first one 

### DIFF
--- a/src/Behat/Mink/Driver/SeleniumDriver.php
+++ b/src/Behat/Mink/Driver/SeleniumDriver.php
@@ -424,7 +424,8 @@ if (node.tagName == 'SELECT') {
     var i, l = nodes.length;
     for (i = 0; i < l; i++) {
         if (nodes[i].getAttribute('value') == "$valueEscaped") {
-            node.checked = true;
+            nodes[i].checked = true;
+            break;
         }
     }
 }


### PR DESCRIPTION
For inputs other then selects with the same name it was checking (selecting) only the first element with the given name.

Changed to check matching node and stop the iteration after it was found.
