### PR TITLE
XPath queries are not properly escaped

### DIFF
--- a/src/Behat/Mink/Driver/SahiDriver.php
+++ b/src/Behat/Mink/Driver/SahiDriver.php
@@ -227,6 +227,7 @@ class SahiDriver implements DriverInterface
      */
     public function find($xpath)
     {
+        $xpath = addcslashes($xpath, "\0..\37\"");
         $function = <<<JS
 (function(){
     var count = 0;


### PR DESCRIPTION
This should fix the problem we're having with xpath queries containg double quotes.
