### PR TITLE
Selenium2 option field selector fix

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -512,7 +512,14 @@ if (tagName == "INPUT") {
         }
     }
 } else {
-  value = "string:" + node.getAttribute('value');
+    attributeValue = node.getAttribute('value');
+    if(attributeValue) {
+        value = "string:" + attributeValue;
+    } else if(node.value) {
+        value = "string:" + node.value;
+    } else {
+        return null;
+    }
 }
 
 return value;

--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -107,4 +107,16 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $draggable->dragTo($droppable);
         $this->assertEquals('Dropped!', $droppable->find('css', 'p')->getText());
     }
+
+    public function testIssue193()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/issue193.html'));
+
+        $session->getPage()->selectFieldOption('options-without-values', 'Two');
+        $this->assertEquals('Two', $session->getPage()->findById('options-without-values')->getValue());
+
+        $session->getPage()->selectFieldOption('options-with-values', 'two');
+        $this->assertEquals('two', $session->getPage()->findById('options-with-values')->getValue());
+    }
 }

--- a/tests/Behat/Mink/Driver/web-fixtures/issue193.html
+++ b/tests/Behat/Mink/Driver/web-fixtures/issue193.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">
+<head>
+    <title>Index page</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+</head>
+<body>
+
+<form action="#">
+    <select id="options-without-values">
+        <option>none selected</option>
+        <option>One</option>
+        <option>Two</option>
+        <option>Three</option>
+    </select>
+
+    <select id="options-with-values">
+        <option value="none">none selected</option>
+        <option value="one">One</option>
+        <option value="two">Two</option>
+        <option value="three">Three</option>
+    </select>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
This fixes issue #193. You can now select form option fields that don't have values set.

Sorry for the previous two pull requests. I was having trouble getting the git and github processes right.
