### PR TITLE
Implement new step definition: 'Then the browser should have a "___" cookie

### DIFF
--- a/features/cookies.feature
+++ b/features/cookies.feature
@@ -1,0 +1,8 @@
+Feature: Mink steps
+  In order to describe web application behavior
+  As a web developer
+  I need to be able to talk with Mink through Behat features
+
+  Scenario: Setting and getting a cookie
+	When I go to "http://www.google.com/"
+	Then the browser should have a "PREF" cookie

--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -326,6 +326,21 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     }
 
     /**
+     * Checks that browser has a cookie
+     *
+     * @Then /^the browser should have an? "(?P<cookieName>[^"]*)" cookie$/
+     */
+    public function assertBrowserHasCookie($cookieName)
+    {
+        try {
+            assertNotEmpty($this->getSession()->getCookie($cookieName));
+        } catch (AssertException $e) {
+            $message = sprintf('Browser does not have a "%s" cookie', $cookieName);
+            throw new ExpectationException($message, $this->getSession(), $e);
+        }
+    }
+
+    /**
      * Checks, that page contains specified text.
      *
      * @Then /^(?:|I )should see "(?P<text>(?:[^"]|\\")*)"$/


### PR DESCRIPTION
Note that the `cookies.feature` test will not pass without the `GoutteDriver::getCookie` fix that I did in commit 298cf12b4a7d14ed57f8114fb0004feca90bef4d (pull request: https://github.com/Behat/Mink/pull/216)
