### PR TITLE
Fixes #168

### DIFF
--- a/src/Behat/Mink/Driver/GoutteDriver.php
+++ b/src/Behat/Mink/Driver/GoutteDriver.php
@@ -374,7 +374,7 @@ class GoutteDriver implements DriverInterface
      */
     public function isChecked($xpath)
     {
-        return true === $this->getValue($xpath);
+        return null !== $this->getAttribute($xpath, 'checked');
     }
 
     /**


### PR DESCRIPTION
GoutteDriver::isChecked was checking the value attribute instead of the checked attribute.
