### PR TITLE
Adding a unit test breaks ZombieDriver testsuite

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -119,4 +119,13 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $session->getPage()->selectFieldOption('options-with-values', 'two');
         $this->assertEquals('two', $session->getPage()->findById('options-with-values')->getValue());
     }
+
+    public function testIssue225()
+    {
+        $this->getSession()->visit($this->pathTo('/issue225.html'));
+        $this->getSession()->getPage()->pressButton('Créer un compte');
+        $this->getSession()->wait(5000, '$("#panel").text() != ""');
+
+        $this->assertContains('OH AIH!', $this->getSession()->getPage()->getText());
+    }
 }

--- a/tests/Behat/Mink/Driver/web-fixtures/issue225.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/issue225.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+<head>
+    <title>Index page</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script src="js/jquery-1.6.2-min.js"></script>
+</head>
+<body>
+
+<button id="btn">Créer un compte</button>
+
+<div id="panel"></div>
+
+<script type="text/javascript">
+    $('#btn').click(function (event) {
+        $('#panel').text('OH ' + 'AIH!');
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
# This PR replace the closed issue #225 :

> Short story
> 
> While hacking some code on Mink, I wrote a little unit test to check a may-or-may-not-exist bug, on pressing a button. When I add it to the test suite, all test that comes after this new test fails, with a RuntimeException: Could not establish connection: Connection refused (61).
> 
> If I remove a simple line of the test, where I try to press a button, the others tests doesn't fail.

The line that break the suite is [this one](https://github.com/Behat/Mink/pull/227/files#L0R126)

(ping @b00giZm)
