### PR TITLE
Url regex

### DIFF
--- a/i18n/cs.xliff
+++ b/i18n/cs.xliff
@@ -99,7 +99,7 @@
             <target><![CDATA[/^musím být na stránce "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^(?:url|adresa|url adresa) musí mít tvar "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/de.xliff
+++ b/i18n/de.xliff
@@ -99,7 +99,7 @@
             <target><![CDATA[/^(?:|ich )sollte auf "(?P<page>[^"]+)" sein$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^die Webadresse sollte mit "(?P<pattern>(?:[^"]|\\")*)" übereinstimmen$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -99,7 +99,7 @@
             <target><![CDATA[/^debo estar en "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^la URL debe seguir el patrón "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/fr.xliff
+++ b/i18n/fr.xliff
@@ -99,8 +99,8 @@
             <target><![CDATA[/^(?:|je )devrais être sur "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
-            <target><![CDATA[/^l'url devrait suivre le motif "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <target><![CDATA[/^l'(?i)url(?-i) devrait suivre le motif "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">
             <source><![CDATA[/^the "(?P<element>[^"]*)" element should contain "(?P<value>(?:[^"]|\\")*)"$/]]></source>

--- a/i18n/ja.xliff
+++ b/i18n/ja.xliff
@@ -95,7 +95,7 @@
             <target><![CDATA[/^(?:|ユーザーが )(?P<page>[^\s]+) を表示していること$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^URLが "(?P<pattern>(?:[^"]|\\")*)" にマッチすること$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/nl.xliff
+++ b/i18n/nl.xliff
@@ -95,7 +95,7 @@
             <target><![CDATA[/^moet (?:|ik )op "(?P<page>[^"]+)" zijn$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^moet de url overeenkomen met "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/pl.xliff
+++ b/i18n/pl.xliff
@@ -99,7 +99,7 @@
             <target><![CDATA[/^(?:|że )powinienem być na stronie "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^(?:url|adres) powinien odpowiadać "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/pt.xliff
+++ b/i18n/pt.xliff
@@ -95,7 +95,7 @@
             <target><![CDATA[/^(?:|Eu )devo de estar em "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^o endereço deve coincidir com "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/ru.xliff
+++ b/i18n/ru.xliff
@@ -99,7 +99,7 @@
             <target><![CDATA[/^(?:|я )должен быть на странице "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^(?:url|адрес) должен соответствовать "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/i18n/sv.xliff
+++ b/i18n/sv.xliff
@@ -95,7 +95,7 @@
             <target><![CDATA[/^(?:|jag )skulle vara på "(?P<page>[^"]+)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-url-should-match">
-            <source><![CDATA[/^the url should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
+            <source><![CDATA[/^the (?i)url(?-i) should match "(?P<pattern>(?:[^"]|\\")*)"$/]]></source>
             <target><![CDATA[/^webbadressen skulle matcha "(?P<pattern>(?:[^"]|\\")*)"$/]]></target>
         </trans-unit>
         <trans-unit id="the-element-should-contain">

--- a/src/Behat/Mink/Behat/Context/BaseMinkContext.php
+++ b/src/Behat/Mink/Behat/Context/BaseMinkContext.php
@@ -277,7 +277,7 @@ abstract class BaseMinkContext extends BehatContext implements TranslatedContext
     /**
      * Checks, that current page PATH matches regular expression.
      *
-     * @Then /^the (?i)url(?-i) should match (?P<pattern>\/([^\/]|\\\/)*\/)$/
+     * @Then /^the (?i)url(?-i) should match (?P<pattern>"(?:[^"]|\\")*")$/
      */
     public function assertUrlRegExp($pattern)
     {


### PR DESCRIPTION
Using / as delimiter when when matching an url is a pain. The delimiter
is now " (which was already used in the translations which were broken
because of that)

This change has been suggested by @grahamc on IRC.

We already use the double quote as delimiter for other places using a regex btw.

Note that this is a BC break as the step definition changed. How should we handle this ? keeping the old pattern along the new one and marking it as deprecated in some way ? And if yes, how ?
