### PR TITLE
Added Selenium2Driver::selectFrame() method

### DIFF
--- a/src/Behat/Mink/Driver/Selenium2Driver.php
+++ b/src/Behat/Mink/Driver/Selenium2Driver.php
@@ -833,4 +833,14 @@ JS;
             sleep(0.1);
         }
     }
+
+    /**
+     * Selects a frame
+     *
+     * @param   string $locator Iframe name or id
+     */
+    public function selectFrame($locator)
+    {
+       return $this->wdSession->frame(array('id' => $locator));
+    }
 }


### PR DESCRIPTION
This method allow to call the webdriver's `frame()` method to change the focus to another frame.
