### PR TITLE
Javascript 'change' not fired on selecting an <option>

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -179,4 +179,18 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
 
         $this->assertContains('OH AIH!', $this->getSession()->getPage()->getText());
     }
+
+    /**
+     * 'change' event should be fired after selecting an <option> in a <select>
+     */
+    public function testIssue255()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/issueChangeSelect.php'));
+
+        $session->getPage()->selectFieldOption('foobar', 'Option 3');
+
+        $session->wait(2000, '$("#output").text() != ""');
+        $this->assertEquals('onChange', $session->getPage()->find('css', '#output')->getText());
+    }
 }

--- a/tests/Behat/Mink/Driver/web-fixtures/issue255.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/issue255.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Issue 255</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <script src="js/jquery-1.6.2-min.js"></script>
+</head>
+<body>
+    <form>
+        <label for="foo_select">Foo</label>
+        <select name="foo_select" id="foo_select">
+            <option value="1" selected="selected" type="text">Option 1</option>
+            <option value="2" type="text">Option 2</option>
+            <option value="3" type="text">Option 3</option>
+        </select>
+        <input type="checkbox" id="foo_check" />
+        <input type="submit" />
+        <p id="output_foo_select"></p>
+        <p id="output_foo_check"></p>
+    </form>
+
+    <script type="text/javascript">
+        (function() {
+            $('#foo_select').change(function () {
+                $('#output_foo_select').text("onChangeSelect");
+            });
+            $('#foo_check').change(function () {
+                $('#output_foo_check').text("onChangeCheck");
+            });
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Hello,

The javascript 'change' event should be fired after selecting an `<option>` in a `<select>`. However this is not the case in the Selenium Driver.

I added a failing testcase on the `JavascriptDriverTest` testsuite, as this behavior should be on any JS-enabled driver.
