### PR TITLE
Preg quote patch

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -488,7 +488,7 @@ class WebAssert
     {
         $node   = $this->fieldExists($field);
         $actual = $node->getValue();
-        $regex  = '/^'.preg_quote($value, '$/').'/ui';
+        $regex  = '/^'.preg_quote($value, '/').'/ui';
 
         if (!preg_match($regex, $actual)) {
             $message = sprintf('The field "%s" value is "%s", but "%s" expected.', $field, $actual, $value);
@@ -508,7 +508,7 @@ class WebAssert
     {
         $node   = $this->fieldExists($field);
         $actual = $node->getValue();
-        $regex  = '/^'.preg_quote($value, '$/').'/ui';
+        $regex  = '/^'.preg_quote($value, '/').'/ui';
 
         if (preg_match($regex, $actual)) {
             $message = sprintf('The field "%s" value is "%s", but it should not be.', $field, $actual);


### PR DESCRIPTION
preg_quote() already escapes $

Also, with php 5.3.10, preg_quote('</b>', '$/') won't work as expected.
