### PR TITLE
Add ability to Mink::assertSession() accept Session object as argument

### DIFF
--- a/src/Behat/Mink/Mink.php
+++ b/src/Behat/Mink/Mink.php
@@ -130,13 +130,16 @@ class Mink
     /**
      * Returns session asserter.
      *
-     * @param string $name session name
+     * @param Session|string $session session object or name
      *
      * @return WebAssert
      */
-    public function assertSession($name = null)
+    public function assertSession($session = null)
     {
-        return new WebAssert($this->getSession($name));
+        if (!($session instanceof Session)) {
+            $session = $this->getSession($session);
+        }
+        return new WebAssert($session);
     }
 
     /**


### PR DESCRIPTION
This is useful when assertSession is called from subroutine which doesn't know session name but has access to session object.
