### PR TITLE
update composer.json for develop branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,13 @@
         "psr-0": {
             "Behat\\Mink": "src/"
         }
-    }
+    },
+
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "1.4.x-dev"
+        }
+    },
+
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Fixes dependency problems on the "develop" branch.

```
    - behat/mink-goutte-driver v1.0.0 requires fabpot/goutte 1.0.* -> no matching package found.
    - behat/mink-goutte-driver v1.0.3 requires fabpot/goutte @dev -> no matching package found.
    - behat/mink-goutte-driver v1.0.2 requires fabpot/goutte 1.0.*@dev -> no matching package found.
    - behat/mink-goutte-driver v1.0.1 requires fabpot/goutte 1.0.x-dev -> no matching package found.
    - Installation request for behat/mink-goutte-driver * -> satisfiable by behat/mink-goutte-driver v1.0.1, behat/mink-goutte-driver v1.0.2, behat/mink-goutte-driver v1.0.3, behat/mink-goutte-driver v1.0.0.
```

and

```
    - behat/mink-zombie-driver v1.0.0 requires behat/mink >=1.4.0,<1.5.0-dev -> satisfiable by behat/mink v1.4.0.
    - behat/mink-zombie-driver dev-master requires behat/mink >=1.4.0,<1.5.0 -> satisfiable by behat/mink v1.4.0.
    - Conclusion: don't install behat/mink v1.4.0
    - Installation request for behat/mink-zombie-driver * -> satisfiable by behat/mink-zombie-driver v1.0.0, behat/mink-zombie-driver dev-master.
```
