### PR TITLE
Adding interface method for resizeWindow()

### DIFF
--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -357,4 +357,13 @@ interface DriverInterface
      * @param string  $condition JS condition
      */
     public function wait($time, $condition);
+
+    /**
+     * Set the dimensions of the window.
+     *
+     * @param integer $width set the window width, measured in pixels
+     * @param integer $height set the window height, measured in pixels
+     * @param string $name window name (null for the main window)
+     */
+    public function resizeWindow($width, $height, $name = null);
 }


### PR DESCRIPTION
Resizing the window is immensely helpful for responsive design.  With this in place, testers can make sure that the CSS and Javascript changes that respond to window dimensions are functioning properly.
