### PR TITLE
Interface method getScreenshot

### DIFF
--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -146,6 +146,14 @@ interface DriverInterface
     public function getContent();
 
     /**
+     * Capture a screenshot of the current window.
+     *
+     * @return  string  screenshot of MIME type image/* depending 
+     *   on driver (e.g., image/png, image/jpeg)
+     */
+    public function getScreenshot();
+
+    /**
      * Finds elements with specified XPath query.
      *
      * @param string $xpath


### PR DESCRIPTION
Screenshots greatly enhace testers ability to both debug failures quickly and to provide visual insights to stakeholders.  It also enables designers to take a more active role in BDD.
