### PR TITLE
Assert cookies separately, order is indeterminate

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -159,7 +159,15 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->getSession()->visit($this->pathTo('/print_cookies.php'));
         $this->assertContains(
-            "array ( 'client_cookie1' = 'some_val', 'client_cookie2' = '123', '_SESS' = ",
+            "'client_cookie1' = 'some_val'",
+            $this->getSession()->getPage()->getText()
+        );
+        $this->assertContains(
+            "'client_cookie2' = '123'",
+            $this->getSession()->getPage()->getText()
+        );
+        $this->assertContains(
+            "_SESS' = ",
             $this->getSession()->getPage()->getText()
         );
         $this->assertContains(


### PR DESCRIPTION
I've been doing a little bit of work on the Zombie driver, getting this test to pass proved tricky, I can't see any reason why they should be asserted to be in any particular order.
