### PR TITLE
Fixed invalid delimiter used in preg_quote to check field value.

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -469,7 +469,7 @@ class WebAssert
     {
         $node   = $this->fieldExists($field);
         $actual = $node->getValue();
-        $regex  = '/^'.preg_quote($value, '$/').'/ui';
+        $regex  = '/^'.preg_quote($value, '/').'/ui';
 
         if (!preg_match($regex, $actual)) {
             $message = sprintf('The field "%s" value is "%s", but "%s" expected.', $field, $actual, $value);


### PR DESCRIPTION
Use '/' instead of '$/' because '$' is the standard character to escape. If use '$/' as delimiter it's impossible to check fields value against date strings as ''25/10/2012".
Error that you can get without this fix is "PHP Warning:  preg_match(): Unknown modifier '1' in vendor/behat/mink/src/Behat/Mink/WebAssert.php on line 474"
