### PR TITLE
Adding hasClass helper to traversable elements

### DIFF
--- a/src/Behat/Mink/Element/TraversableElement.php
+++ b/src/Behat/Mink/Element/TraversableElement.php
@@ -92,6 +92,22 @@ abstract class TraversableElement extends Element
     }
 
     /**
+     * Checks whether an element has a named CSS class
+     *
+     * @param string $className Name of the class
+     *
+     * @return boolean
+     */
+    public function hasClass($className)
+    {
+        if ($this->hasAttribute('class')) {
+            return in_array($className, explode(' ', $this->getAttribute('class')));
+        }
+        
+        return false;
+    }
+
+    /**
      * Finds button (input[type=submit|image|button], button) with specified locator.
      *
      * @param string $locator button id, value or alt

--- a/tests/Behat/Mink/Element/NodeElementTest.php
+++ b/tests/Behat/Mink/Element/NodeElementTest.php
@@ -66,6 +66,21 @@ class NodeElementTest extends ElementTest
         $this->assertEquals('http://...', $node->getAttribute('href'));
     }
 
+    public function testHasClass()
+    {
+        $node = new NodeElement('input_tag', $this->session);
+        
+        $this->session->getDriver()
+            ->expects($this->exactly(6))
+            ->method('getAttribute')
+            ->with('input_tag', 'class')
+            ->will($this->returnValue('class1 class2'));
+
+        $this->assertTrue($node->hasClass('class1'));
+        $this->assertTrue($node->hasClass('class2'));
+        $this->assertFalse($node->hasClass('class3'));
+    }
+
     public function testGetValue()
     {
         $node = new NodeElement('input_tag', $this->session);


### PR DESCRIPTION
This adds a method to traversable elements, that allows you to check whether the element has a specific CSS class assigned to it or not.
