### PR TITLE
Container parameter for elementExists methods

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -2,7 +2,8 @@
 
 namespace Behat\Mink;
 
-use Behat\Mink\Element\NodeElement,
+use Behat\Mink\Element\Element,
+    Behat\Mink\Element\NodeElement,
     Behat\Mink\Exception\ElementNotFoundException,
     Behat\Mink\Exception\ExpectationException,
     Behat\Mink\Exception\ResponseTextException,
@@ -319,16 +320,18 @@ class WebAssert
     /**
      * Checks that specific element exists on the current page.
      *
-     * @param string $selectorType element selector type (css, xpath)
-     * @param string $selector     element selector
+     * @param string  $selectorType element selector type (css, xpath)
+     * @param string  $selector     element selector
+     * @param Element $container    document to check against
      *
      * @return NodeElement
      *
      * @throws ElementNotFoundException
      */
-    public function elementExists($selectorType, $selector)
+    public function elementExists($selectorType, $selector, Element $container = null)
     {
-        $node = $this->session->getPage()->find($selectorType, $selector);
+        $container = ($container !== null) ? $container : $this->session->getPage();
+        $node = $container->find($selectorType, $selector);
 
         if (null === $node) {
             throw new ElementNotFoundException($this->session, 'element', $selectorType, $selector);
@@ -340,14 +343,16 @@ class WebAssert
     /**
      * Checks that specific element does not exists on the current page.
      *
-     * @param string $selectorType element selector type (css, xpath)
-     * @param string $selector     element selector
+     * @param string  $selectorType element selector type (css, xpath)
+     * @param string  $selector     element selector
+     * @param Element $container    document to check against
      *
      * @throws ExpectationException
      */
-    public function elementNotExists($selectorType, $selector)
+    public function elementNotExists($selectorType, $selector, Element $container = null)
     {
-        $node = $this->session->getPage()->find($selectorType, $selector);
+        $container = ($container !== null) ? $container : $this->session->getPage();
+        $node = $container->find($selectorType, $selector);
 
         if (null !== $node) {
             $message = sprintf('An element matching %s "%s" appears on this page, but it should not.', $selectorType, $selector);

--- a/tests/Behat/Mink/WebAssertTest.php
+++ b/tests/Behat/Mink/WebAssertTest.php
@@ -395,15 +395,22 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         ;
 
         $page
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(4))
             ->method('find')
             ->with('css', 'h2 > span')
-            ->will($this->onConsecutiveCalls(1, null))
+            ->will($this->onConsecutiveCalls(1, null, 1, null))
         ;
 
         $this->assertCorrectAssertion('elementExists', array('css', 'h2 > span'));
         $this->assertWrongAssertion(
             'elementExists', array('css', 'h2 > span'),
+            'Behat\\Mink\\Exception\\ElementNotFoundException',
+            'Element matching css "h2 > span" not found.'
+        );
+
+        $this->assertCorrectAssertion('elementExists', array('css', 'h2 > span', $page));
+        $this->assertWrongAssertion(
+            'elementExists', array('css', 'h2 > span', $page),
             'Behat\\Mink\\Exception\\ElementNotFoundException',
             'Element matching css "h2 > span" not found.'
         );
@@ -423,15 +430,22 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         ;
 
         $page
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(4))
             ->method('find')
             ->with('css', 'h2 > span')
-            ->will($this->onConsecutiveCalls(null, 1))
+            ->will($this->onConsecutiveCalls(null, 1, null, 1))
         ;
 
         $this->assertCorrectAssertion('elementNotExists', array('css', 'h2 > span'));
         $this->assertWrongAssertion(
             'elementNotExists', array('css', 'h2 > span'),
+            'Behat\\Mink\\Exception\\ExpectationException',
+            'An element matching css "h2 > span" appears on this page, but it should not.'
+        );
+
+        $this->assertCorrectAssertion('elementNotExists', array('css', 'h2 > span', $page));
+        $this->assertWrongAssertion(
+            'elementNotExists', array('css', 'h2 > span', $page),
             'Behat\\Mink\\Exception\\ExpectationException',
             'An element matching css "h2 > span" appears on this page, but it should not.'
         );


### PR DESCRIPTION
Allows you to pass in an element as a container, to assert another element exists within it.

Contributes to #293.
