### PR TITLE
Adding ability to inject custom page into session

### DIFF
--- a/src/Behat/Mink/Session.php
+++ b/src/Behat/Mink/Session.php
@@ -4,7 +4,8 @@ namespace Behat\Mink;
 
 use Behat\Mink\Driver\DriverInterface,
     Behat\Mink\Selector\SelectorsHandler,
-    Behat\Mink\Element\DocumentElement;
+    Behat\Mink\Element\DocumentElement,
+    Behat\Mink\Element\Element;
 
 /*
  * This file is part of the Behat\Mink.
@@ -100,11 +101,21 @@ class Session
     /**
      * Returns page element.
      *
-     * @return DocumentElement
+     * @return Element
      */
     public function getPage()
     {
         return $this->page;
+    }
+
+    /**
+     * Sets page element
+     *
+     * @param Element $page
+     */
+    public function setPage(Element $page)
+    {
+        $this->page = $page;
     }
 
     /**
@@ -205,7 +216,7 @@ class Session
     /**
      * Capture a screenshot of the current window.
      *
-     * @return  string  screenshot of MIME type image/* depending 
+     * @return  string  screenshot of MIME type image/* depending
      *   on driver (e.g., image/png, image/jpeg)
      */
     public function getScreenshot()

--- a/tests/Behat/Mink/SessionTest.php
+++ b/tests/Behat/Mink/SessionTest.php
@@ -27,7 +27,18 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPage()
     {
-        $this->assertInstanceOf('Behat\Mink\Element\DocumentElement', $this->session->getPage());
+        $this->assertInstanceOf('Behat\Mink\Element\Element', $this->session->getPage());
+    }
+
+    public function testSetPage()
+    {
+        $page = $this->getMockBuilder('Behat\Mink\Element\Element')
+            ->setConstructorArgs(array($this->session))
+            ->getMock();
+
+        $this->session->setPage($page);
+
+        $this->assertSame($page, $this->session->getPage());
     }
 
     public function testGetSelectorsHandler()


### PR DESCRIPTION
At this time to use custom selector we need to extend Element\Element then create custom session to return custom page from it then create custom context and custom initializer. But session for page is a container; so if we add ability to inject custom page to container we won't need to use custom session.
