### PR TITLE
Consistent handling of whitespaces in WebAssert::pageText[Not]Contains()

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -168,6 +168,7 @@ class WebAssert
     public function pageTextContains($text)
     {
         $actual = $this->session->getPage()->getText();
+        $actual = preg_replace('/\s+/', ' ', $actual);
         $regex  = '/'.preg_quote($text, '/').'/ui';
 
         if (!preg_match($regex, $actual)) {
@@ -186,6 +187,7 @@ class WebAssert
     public function pageTextNotContains($text)
     {
         $actual = $this->session->getPage()->getText();
+        $actual = preg_replace('/\s+/', ' ', $actual);
         $regex  = '/'.preg_quote($text, '/').'/ui';
 
         if (preg_match($regex, $actual)) {

--- a/tests/Behat/Mink/WebAssertTest.php
+++ b/tests/Behat/Mink/WebAssertTest.php
@@ -152,7 +152,7 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         $page
             ->expects($this->exactly(2))
             ->method('getText')
-            ->will($this->returnValue('Some page text'))
+            ->will($this->returnValue("Some  page\n\ttext"))
         ;
 
         $this->assertCorrectAssertion('pageTextContains', array('PAGE text'));
@@ -179,7 +179,7 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         $page
             ->expects($this->exactly(2))
             ->method('getText')
-            ->will($this->returnValue('Some html text'))
+            ->will($this->returnValue("Some  html\n\ttext"))
         ;
 
         $this->assertCorrectAssertion('pageTextNotContains', array('PAGE text'));


### PR DESCRIPTION
I came across the issue, that multiple whitespace characters between words would make a step like the following fail, although from a user point of view it should pass.

```
Then I should see "Some text"
```

My suggested fix is to convert all whitespaces to a single space character before comparing with the expected text.
