### PR TITLE
Fixed README.md example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ $startUrl = 'http://example.com';
 
 // init Mink and register sessions
 $mink = new Mink(array(
-    'goutte1' => new Session(new GoutteDriver(GoutteClient($startUrl))),
-    'goutte2' => new Session(new GoutteDriver(GoutteClient($startUrl))),
+    'goutte1' => new Session(new GoutteDriver(new GoutteClient())),
+    'goutte2' => new Session(new GoutteDriver(new GoutteClient())),
     'custom'  => new Session(new MyCustomDriver($startUrl))
 ));
 
 // set the default session name
 $mink->setDefaultSessionName('goutte2');
+
+// visit a page
+$mink->visit($startUrl);
 
 // call to getSession() without argument will always return a default session if has one (goutte2 here)
 $mink->getSession()->getPage()->findLink('Downloads')->click();


### PR DESCRIPTION
Hello,
there was an error in README. I fixed it a little bit. GoutteClient has different constructor parameters and there was new keyword missing.
