### PR TITLE
Added Mink::isSessionStarted to check if a request has been made

### DIFF
--- a/src/Behat/Mink/Mink.php
+++ b/src/Behat/Mink/Mink.php
@@ -97,27 +97,17 @@ class Mink
     }
 
     /**
-     * Returns registered session by it's name or active one.
+     * Returns registered session by it's name or active one and automatically starts it if required.
      *
      * @param string $name session name
      *
      * @return Session
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException If the named session is not registered
      */
     public function getSession($name = null)
     {
-        $name = strtolower($name) ?: $this->defaultSessionName;
-
-        if (null === $name) {
-            throw new \InvalidArgumentException('Specify session name to get');
-        }
-
-        if (!isset($this->sessions[$name])) {
-            throw new \InvalidArgumentException(sprintf('Session "%s" is not registered.', $name));
-        }
-
-        $session = $this->sessions[$name];
+        $session = $this->locateSession($name);
 
         // start session if needed
         if (!$session->isStarted()) {
@@ -125,6 +115,21 @@ class Mink
         }
 
         return $session;
+    }
+
+    /**
+     * Checks whether a named session (or the default session) has already been started
+     *
+     * @param string $name session name - if null then the default session will be checked
+     *
+     * @return bool whether the session has been started
+     *
+     * @throws \InvalidArgumentException If the named session is not registered
+     */
+    public function isSessionStarted($name = null)
+    {
+        $session = $this->locateSession($name);
+        return $session->isStarted();
     }
 
     /**
@@ -176,5 +181,30 @@ class Mink
                 $session->stop();
             }
         }
+    }
+
+    /**
+     * Returns the named or default session without starting it.
+     *
+     * @param string $name session name
+     *
+     * @return Session
+     *
+     * @throws \InvalidArgumentException If the named session is not registered
+     */
+    protected function locateSession($name = null)
+    {
+        $name = strtolower($name) ?: $this->defaultSessionName;
+
+        if (null === $name) {
+            throw new \InvalidArgumentException('Specify session name to get');
+        }
+
+        if (!isset($this->sessions[$name])) {
+            throw new \InvalidArgumentException(sprintf('Session "%s" is not registered.', $name));
+        }
+
+        $session = $this->sessions[$name];
+        return $session;
     }
 }

--- a/tests/Behat/Mink/MinkTest.php
+++ b/tests/Behat/Mink/MinkTest.php
@@ -136,6 +136,40 @@ class MinkTest extends \PHPUnit_Framework_TestCase
         $this->mink->getSession();
     }
 
+    public function testIsSessionStarted()
+    {
+        $session_1 = $this->getSessionMock();
+        $session_2 = $this->getSessionMock();
+
+        $session_1
+            ->expects($this->any())
+            ->method('isStarted')
+            ->will($this->returnValue(false));
+        $session_1
+            ->expects($this->never())
+            ->method('start');
+
+        $session_2
+            ->expects($this->any())
+            ->method('isStarted')
+            ->will($this->returnValue(true));
+        $session_2
+            ->expects($this->never())
+            ->method('start');
+
+        $this->mink->registerSession('not_started', $session_1);
+        $this->assertFalse($this->mink->isSessionStarted('not_started'));
+
+        $this->mink->registerSession('started', $session_2);
+        $this->assertTrue($this->mink->isSessionStarted('started'));
+
+        $this->setExpectedException('InvalidArgumentException');
+
+        $this->mink->getSession('not_registered');
+    }
+
+
+
     private function getSessionMock()
     {
         return $this->getMockBuilder('Behat\Mink\Session')


### PR DESCRIPTION
@everzet this is the pull request for Behat/Mink#273 - I named the method isSessionStarted which I thought was clearer than isStarted in that context. I've mirrored the API (and tests) for getSession, and therefore refactored the code that checks the session exists into a shared method.

I tried to follow your coding style and testcase structure - do let me know if there's anything you want to see different.

Thanks.
