### PR TITLE
Fixed the testsuite with Symfony 2.3

### DIFF
--- a/tests/Behat/Mink/Selector/CssSelectorTest.php
+++ b/tests/Behat/Mink/Selector/CssSelectorTest.php
@@ -19,6 +19,13 @@ class CssSelectorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('descendant-or-self::h3', $selector->translateToXPath('h3'));
         $this->assertEquals('descendant-or-self::h3/span', $selector->translateToXPath('h3 > span'));
-        $this->assertEquals("descendant-or-self::h3/*[contains(concat(' ', normalize-space(@class), ' '), ' my_div ')]", $selector->translateToXPath('h3 > .my_div'));
+
+        if (interface_exists('Symfony\Component\CssSelector\XPath\TranslatorInterface')) {
+            // The rewritten component of Symfony 2.3 checks for attribute existence first for the class.
+            $expectation = "descendant-or-self::h3/*[@class and contains(concat(' ', normalize-space(@class), ' '), ' my_div ')]";
+        } else {
+            $expectation = "descendant-or-self::h3/*[contains(concat(' ', normalize-space(@class), ' '), ' my_div ')]";
+        }
+        $this->assertEquals($expectation, $selector->translateToXPath('h3 > .my_div'));
     }
 }


### PR DESCRIPTION
The CssSelector has been rewritten entirely for 2.3 and the generated XPath query is a bit different for classes (based on the latest version of the original Python library).

I'm detecting one of the interfaces added in the rewritten version to figure that it si used as there is no version constant in CssSelector (only HttpKernel has it)
