### PR TITLE
Cookie setting test failed on PHP 5.4 because cookie retrieval order

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -171,7 +171,7 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
             $this->getSession()->getPage()->getText()
         );
         $this->assertContains(
-            " 'srvr_cookie' = 'srv_var_is_set', )",
+            " 'srvr_cookie' = 'srv_var_is_set'",
             $this->getSession()->getPage()->getText()
         );
 


### PR DESCRIPTION
Fixes test case, that were expecting cookies are reported (by PHP) in same order, as they were set by Driver.

Unfortunately that didn't work in PHP 5.4.
