### PR TITLE
Allow to run use web-fixtures on existing VirtualHost in a sub-folder

### DIFF
--- a/tests/Behat/Mink/Driver/web-fixtures/advanced_form.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/advanced_form.php
@@ -7,7 +7,7 @@
 <body>
     <h1>ADvanced Form Page</h1>
 
-    <form method="POST" enctype="multipart/form-data" action="/advanced_form_post.php">
+    <form method="POST" enctype="multipart/form-data" action="advanced_form_post.php">
         <input name="first_name" value="Firstname" type="text" />
         <input id="lastn" name="last_name" value="Lastname" type="text" />
         <label for="email">

--- a/tests/Behat/Mink/Driver/web-fixtures/aria_roles.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/aria_roles.php
@@ -14,7 +14,7 @@
 	<!-- This link is created programmatically -->
 	<div id="link-element"></div>
 
-    <script language="javascript" type="text/javascript" src="/js/jquery-1.6.2-min.js"></script>
+    <script language="javascript" type="text/javascript" src="js/jquery-1.6.2-min.js"></script>
 	<script language="javascript" type="text/javascript">
 		$(document).ready(function() {
 			$('#hidden-element-toggle-button').click(function() {
@@ -22,7 +22,7 @@
 			});
 
 			$('#link-element').attr('role', 'link').text('Go to Index').click(function() {
-        window.location.href = '/index.php';
+        window.location.href = 'index.php';
 			});
 		});
 	</script>

--- a/tests/Behat/Mink/Driver/web-fixtures/issue130.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/issue130.php
@@ -6,7 +6,7 @@
 <body>
     <?php
     if ('1' === $_GET['p']) {
-        echo '<a href="/issue130.php?p=2">Go to 2</a>';
+        echo '<a href="issue130.php?p=2">Go to 2</a>';
     } else {
         echo '<strong>'.$_SERVER['HTTP_REFERER'].'</strong>';
     }

--- a/tests/Behat/Mink/Driver/web-fixtures/links.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/links.php
@@ -7,8 +7,8 @@
 <body>
     <a href="redirector.php">Redirect me to</a>
     <a href="randomizer.php">Random number page</a>
-    <a href="/links.php?quoted">Link with a '</a>
-    <a href="/basic_form.php">
+    <a href="links.php?quoted">Link with a '</a>
+    <a href="basic_form.php">
         <img src="basic_form" alt="basic form image"/>
     </a>
 </body>

--- a/tests/Behat/Mink/Driver/web-fixtures/multiselect_form.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/multiselect_form.php
@@ -7,7 +7,7 @@
 <body>
     <h1>Multiselect Test</h1>
 
-    <form method="POST" action="/advanced_form_post.php">
+    <form method="POST" action="advanced_form_post.php">
         <select name="select_number">
             <option value="10">ten</option>
             <option selected="selected" value="20">twenty</option>

--- a/tests/Behat/Mink/Driver/web-fixtures/redirector.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/redirector.php
@@ -1,3 +1,3 @@
 <?php
 
-header('location: /redirect_destination.php');
+header('location: redirect_destination.php');


### PR DESCRIPTION
Some test fixtures where having urls beginning with `/` which wasn't preventing tests from running in case, when no separate VirtualHost was setup, where `web-fixtures` folder was set as it's DocumentRoot.
