### PR TITLE
__wakeup() should reset session list, since they are most likely outdated.

### DIFF
--- a/src/Behat/Mink/Mink.php
+++ b/src/Behat/Mink/Mink.php
@@ -207,4 +207,12 @@ class Mink
         $session = $this->sessions[$name];
         return $session;
     }
+
+
+    /**
+     * Mink class might wake up after un-serialization, but all of it's old sessions are most likely closed by someone else.
+     */
+    function __wakeup() {
+        $this->sessions = array();
+    }
 }


### PR DESCRIPTION
Here's the scenario where you get this problem:
1. You run the parallel test suite (either with gearman or with SG runner).
2. In your client class, you get the test results as a bunch of serialized event classes, which also have references to Mink, which makes it serialized as well.
3. Parallel workers end their Mink sessions just fine, but then unserialized Mink instance in client, which have references to the same sessions, throw exceptions during their __destruct() stage, because they can't stop sessions, which are already finished.

The solution is to just strip session list in Mink during unserialization.
