### PR TITLE
Session driver-independent way to make sessions unique

### DIFF
--- a/src/Behat/Mink/Session.php
+++ b/src/Behat/Mink/Session.php
@@ -24,6 +24,7 @@ class Session
     private $driver;
     private $page;
     private $selectorsHandler;
+    private $uniqueId;
 
     /**
      * Initializes session.
@@ -42,6 +43,7 @@ class Session
         $this->driver           = $driver;
         $this->page             = new DocumentElement($this);
         $this->selectorsHandler = $selectorsHandler;
+        $this->uniqueId         = uniqid('mink_session_');
     }
 
     /**
@@ -95,6 +97,17 @@ class Session
     public function getDriver()
     {
         return $this->driver;
+    }
+
+    /**
+     * Returns session unique id.
+     *
+     * @return string
+     * @access public
+     */
+    public function getUniqueId()
+    {
+        return $this->uniqueId;
     }
 
     /**
@@ -205,7 +218,7 @@ class Session
     /**
      * Capture a screenshot of the current window.
      *
-     * @return  string  screenshot of MIME type image/* depending 
+     * @return  string  screenshot of MIME type image/* depending
      *   on driver (e.g., image/png, image/jpeg)
      */
     public function getScreenshot()

--- a/tests/Behat/Mink/SessionTest.php
+++ b/tests/Behat/Mink/SessionTest.php
@@ -11,6 +11,13 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 {
     private $driver;
     private $selectorsHandler;
+
+    /**
+     * Session.
+     *
+     * @var Session
+     * @access private
+     */
     private $session;
 
     protected function setUp()
@@ -113,5 +120,19 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             ->with(1000, 'function() {}');
 
         $this->session->wait(1000, 'function() {}');
+    }
+
+    /**
+     * Testing that 2 sessions created with same parameters have different IDs.
+     *
+     * @return void
+     * @access public
+     */
+    public function testUniqueId()
+    {
+        $session  = new Session($this->driver, $this->selectorsHandler);
+
+        $this->assertNotEquals($session->getUniqueId(), $this->session->getUniqueId());
+
     }
 }


### PR DESCRIPTION
Right now some of drivers have ways to identify their own sessions. However not all of them are willing to share that information, nor it's in a unified format.

Using `spl_object_hash` also isn't possible with `Session` class instances, because data object properties can change over time.

Here is a way to allow unique identification of each session.

Usage:

``` php
$session = new Session(.....);
$unique_id = $session->getUniqueId();
```
