### PR TITLE
accepting hashtag navigation

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -46,7 +46,7 @@ class WebAssert
      */
     public function addressEquals($page)
     {
-        $expected = $this->cleanScriptnameFromPath(parse_url($page, PHP_URL_PATH));
+        $expected = $this->cleanUrl($page);
         $actual   = $this->getCurrentUrlPath();
 
         if ($actual !== $expected) {
@@ -64,7 +64,7 @@ class WebAssert
      */
     public function addressNotEquals($page)
     {
-        $expected = $this->cleanScriptnameFromPath(parse_url($page, PHP_URL_PATH));
+        $expected = $this->cleanUrl($page);
         $actual   = $this->getCurrentUrlPath();
 
         if ($actual === $expected) {
@@ -574,9 +574,7 @@ class WebAssert
      */
     protected function getCurrentUrlPath()
     {
-        return $this->cleanScriptnameFromPath(
-            parse_url($this->session->getCurrentUrl(), PHP_URL_PATH)
-        );
+        return $this->cleanUrl($this->session->getCurrentUrl());
     }
 
     /**
@@ -586,8 +584,10 @@ class WebAssert
      *
      * @return string
      */
-    protected function cleanScriptnameFromPath($path)
+    protected function cleanUrl($url)
     {
-        return preg_replace('/^\/[^\.\/]+\.php/', '', $path);
+        $parts = parse_url($url);
+        $fragment = empty($parts['fragment']) ? '' : '#' . $parts['fragment'];
+        return preg_replace('/^\/[^\.\/]+\.php/', '', $parts['path']) . $fragment;
     }
 }

--- a/tests/Behat/Mink/WebAssertTest.php
+++ b/tests/Behat/Mink/WebAssertTest.php
@@ -31,14 +31,14 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         $this->session
             ->expects($this->exactly(2))
             ->method('getCurrentUrl')
-            ->will($this->returnValue('http://example.com/script.php/sub/url'))
+            ->will($this->returnValue('http://example.com/script.php/sub/url?param=true#webapp/nav'))
         ;
 
-        $this->assertCorrectAssertion('addressEquals', array('/sub/url'));
+        $this->assertCorrectAssertion('addressEquals', array('/sub/url#webapp/nav'));
         $this->assertWrongAssertion(
             'addressEquals', array('sub_url'),
             'Behat\\Mink\\Exception\\ExpectationException',
-            'Current page is "/sub/url", but "sub_url" expected.'
+            'Current page is "/sub/url#webapp/nav", but "sub_url" expected.'
         );
     }
 


### PR DESCRIPTION
In javascript based webapps you often use hashtag based navigation - Mink ignores everything after # and sees all urls as root / meaning that it impossible to test urls
