### PR TITLE
Add __clone to Session.

### DIFF
--- a/src/Behat/Mink/Session.php
+++ b/src/Behat/Mink/Session.php
@@ -45,6 +45,19 @@ class Session
     }
 
     /**
+     * Clones this session
+     *
+     * Clones the driver and freshens up references and uniqueId.
+     */
+    public function __clone() {
+      $this->driver = clone $this->driver;
+      $this->driver->setSession($this);
+      $this->selectorsHandler = clone $this->selectorsHandler;
+      $this->uniqueId         = uniqid('mink_session_');
+      $this->page = new DocumentElement($this);
+    }
+
+    /**
      * Checks whether session (driver) was started.
      *
      * @return Boolean


### PR DESCRIPTION
Cloning a Session now creates a new driver & uniqueId, so that a
cloned session is a truly seperate but very similar browsing context.
