### PR TITLE
Test "GeneralDriverTest::testLinks" don't pass on Firefox 23

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -361,7 +361,7 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         $page = $this->getSession()->getPage();
         $link = $page->findLink('basic form image');
 
-        $this->assertRegExp('/\/basic_form\.php$/', $link->getAttribute('href'));
+        $this->assertRegExp('/basic_form\.php$/', $link->getAttribute('href'));
         $link->click();
 
         $this->assertEquals($this->pathTo('/basic_form.php'), $this->getSession()->getCurrentUrl());
@@ -371,7 +371,7 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         $link = $page->findLink("Link with a ");
 
         $this->assertNotNull($link);
-        $this->assertRegExp('/\/links\.php\?quoted$/', $link->getAttribute('href'));
+        $this->assertRegExp('/links\.php\?quoted$/', $link->getAttribute('href'));
         $link->click();
 
         $this->assertEquals($this->pathTo('/links.php?quoted'), $this->getSession()->getCurrentUrl());


### PR DESCRIPTION
When running https://github.com/Behat/MinkSeleniumDriver tests on Firefox 23, then `GeneralDriverTest::testLinks` test don't pass becase of `getAttribute('href')` call returns `basic_form.php` instead of `http://test.mink.dev/basic_form.php`. Same for `links\.php?quoted` link.

Original test was created in: https://github.com/Behat/Mink/pull/255.
