### PR TITLE
Ability to submit forms

### DIFF
--- a/src/Behat/Mink/Driver/CoreDriver.php
+++ b/src/Behat/Mink/Driver/CoreDriver.php
@@ -303,4 +303,14 @@ abstract class CoreDriver implements DriverInterface
     {
         throw new UnsupportedDriverActionException('Window resizing is not supported by %s', $this);
     }
+
+    /**
+     * Submits the form.
+     *
+     * @param string $xpath Xpath.
+     */
+    public function submitForm($xpath)
+    {
+        throw new UnsupportedDriverActionException('Form submission is not supported by %s', $this);
+    }
 }

--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -374,4 +374,11 @@ interface DriverInterface
      * @param string $name window name (null for the main window)
      */
     public function resizeWindow($width, $height, $name = null);
+
+    /**
+     * Submits the form.
+     *
+     * @param string $xpath Xpath.
+     */
+    public function submitForm($xpath);
 }

--- a/src/Behat/Mink/Element/NodeElement.php
+++ b/src/Behat/Mink/Element/NodeElement.php
@@ -315,4 +315,12 @@ class NodeElement extends TraversableElement
     {
         $this->getSession()->getDriver()->keyUp($this->getXpath(), $char, $modifier);
     }
+
+    /**
+     * Submits the form.
+     */
+    public function submit()
+    {
+        $this->getSession()->getDriver()->submitForm($this->getXpath());
+    }
 }

--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -414,6 +414,18 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Lastname: Kudryashov', $page->find('css', '#last')->getText());
     }
 
+    public function testFormSubmit()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/basic_form.php'));
+
+        $page = $session->getPage();
+        $page->findField('first_name')->setValue('Konstantin');
+        $page->find('xpath', 'descendant-or-self::form[1]')->submit();
+
+        $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+    }
+
     public function testBasicGetForm()
     {
         $this->getSession()->visit($this->pathTo('/basic_get_form.php'));

--- a/tests/Behat/Mink/Element/NodeElementTest.php
+++ b/tests/Behat/Mink/Element/NodeElementTest.php
@@ -69,7 +69,7 @@ class NodeElementTest extends ElementTest
     public function testHasClass()
     {
         $node = new NodeElement('input_tag', $this->session);
-        
+
         $this->session->getDriver()
             ->expects($this->exactly(6))
             ->method('getAttribute')
@@ -265,5 +265,17 @@ class NodeElementTest extends ElementTest
             ->with('some_tag1', 'some_tag3');
 
         $node->dragTo(new NodeElement('some_tag2', $this->session));
+    }
+
+    public function testSubmitForm()
+    {
+        $node = new NodeElement('some_xpath', $this->session);
+
+        $this->session->getDriver()
+            ->expects($this->once())
+            ->method('submitForm')
+            ->with('some_xpath');
+
+        $node->submit();
     }
 }


### PR DESCRIPTION
Adds `submit` method for `NodeElement` matching. Implementation of https://github.com/Behat/Mink/issues/336.
