### PR TITLE
Keep CoreDriver in sync with DriverInterface

### DIFF
--- a/src/Behat/Mink/Driver/CoreDriver.php
+++ b/src/Behat/Mink/Driver/CoreDriver.php
@@ -149,7 +149,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * Return the names of all open windows
+     * Return the names of all open windows.
      *
      * @return array    array of all open windows
      */
@@ -159,7 +159,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * Return the name of the currently active window
+     * Return the name of the currently active window.
      *
      * @return string    the name of the current window
      */

--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -154,6 +154,20 @@ interface DriverInterface
     public function getScreenshot();
 
     /**
+     * Return the names of all open windows.
+     *
+     * @return array    array of all open windows
+     */
+    public function getWindowNames();
+
+    /**
+     * Return the name of the currently active window.
+     *
+     * @return string    the name of the current window
+     */
+    public function getWindowName();
+
+    /**
      * Finds elements with specified XPath query.
      *
      * @param string $xpath


### PR DESCRIPTION
I've noticed, that during https://github.com/Behat/Mink/pull/341 development new `getWindowNames` and `getWindowName` methods were added to `DriverInterface` (which is correct), but then after several commits they were removed (probably due accident).

I've added them back and also added missing dot in their DocBlock's.
