### PR TITLE
Protection against premature page operations after form submission

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -398,7 +398,8 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testBasicForm()
     {
-        $this->getSession()->visit($this->pathTo('/basic_form.php'));
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/basic_form.php'));
 
         $page = $this->getSession()->getPage();
         $this->assertEquals('Basic Form Page', $page->find('css', 'h1')->getText());
@@ -420,9 +421,11 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
 
         $page->findButton('Save')->click();
 
-        $this->assertEquals('Anket for Konstantin', $page->find('css', 'h1')->getText());
-        $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
-        $this->assertEquals('Lastname: Kudryashov', $page->find('css', '#last')->getText());
+        if ( $session->wait(5000, 'document.getElementById("first") !== null') ) {
+            $this->assertEquals('Anket for Konstantin', $page->find('css', 'h1')->getText());
+            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+            $this->assertEquals('Lastname: Kudryashov', $page->find('css', '#last')->getText());
+        }
     }
 
     public function testFormSubmit()
@@ -434,7 +437,9 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         $page->findField('first_name')->setValue('Konstantin');
         $page->find('xpath', 'descendant-or-self::form[1]')->submit();
 
-        $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+        if ( $session->wait(5000, 'document.getElementById("first") !== null') ) {
+            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+        };
     }
 
     public function testBasicGetForm()


### PR DESCRIPTION
It appears, that some drivers (e.g. MinkSeleniumDriver) are performing form submission slower (a bit) when dedicated `submit` method is used, rather when a `click` is made on `<input type='submit' .../>` button. For that reason there might be a delay before actual page is available to the driver after form submission was made.

In reality a `testFormSubmit` test was failing because of that. Just to be on the safe side I've added protection (using `wait` method) to both `testFormSubmit` and `testBasicForm` tests.
