### PR TITLE
Sorting $_POST array output in `advanced_form_post.php`

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -493,12 +493,13 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
 
         $space = ' ';
         $this->assertContains(<<<OUT
-  'select_number' = '30',
+  'agreement' = 'off',
   'select_multiple_numbers' =$space
   array (
     0 = '1',
     1 = '3',
-  )
+  ),
+  'select_number' = '30',
 OUT
             , $page->getContent()
         );
@@ -578,12 +579,12 @@ OUT
         $space = ' ';
         $this->assertContains(<<<OUT
 array (
+  'agreement' = 'on',
+  'email' = 'ever.zet@gmail.com',
   'first_name' = 'Foo "item"',
   'last_name' = 'Bar',
-  'email' = 'ever.zet@gmail.com',
   'select_number' = '30',
   'sex' = 'm',
-  'agreement' = 'on',
   'submit' = 'Register',
 )
 1 uploaded file
@@ -617,14 +618,17 @@ OUT
         $button = $page->findButton('Login');
         $button->press();
 
-        $this->assertContains(<<<OUT
-  'submit' = 'Login',
-  'agreement' = 'off',
-)
-no file
-OUT
-            , $page->getContent()
+        $toSearch = array(
+            "'agreement' = 'off',",
+            "'submit' = 'Login',",
+            'no file',
         );
+
+        $pageContent = $page->getContent();
+
+        foreach ($toSearch as $searchString) {
+            $this->assertContains($searchString, $pageContent);
+        }
     }
 
     protected function pathTo($path)

--- a/tests/Behat/Mink/Driver/web-fixtures/advanced_form_post.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/advanced_form_post.php
@@ -8,13 +8,14 @@
 <?php
     error_reporting(0);
 
-    if (false !== strpos($_POST['select_multiple_numbers'][0], ',')) {
+    if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_multiple_numbers'][0], ',')) {
         $_POST['select_multiple_numbers'] = explode(',', $_POST['select_multiple_numbers'][0]);
     }
 
     $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
+    ksort($_POST);
     echo str_replace('>', '', var_export($_POST, true)) . "\n";
-    if (file_exists($_FILES['about']['tmp_name'])) {
+    if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
         echo file_get_contents($_FILES['about']['tmp_name']);
     } else {
         echo "no file";


### PR DESCRIPTION
Sorting $_POST array output in `advanced_form_post.php` to prevent any randomly failing tests with headless drivers. Minor improvements to the file, made in MinkBrowserKitDriver-specific file copy.

Relates to: #394
