### PR TITLE
New test to verify correct work of `getAttribute` method

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -291,6 +291,26 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('div', $element->getTagName());
     }
 
+    /**
+     * @dataProvider getAttributeDataProvider
+     */
+    public function testGetAttribute($attributeName, $attributeValue)
+    {
+        $element = $this->getSession()->getPage()->findById('attr-elem[' . $attributeName . ']');
+
+        $this->assertSame($attributeValue, $element->getAttribute($attributeName));
+    }
+
+    public function getAttributeDataProvider()
+    {
+    	return array(
+            array('with-value', 'some-value'),
+            array('without-value', ''),
+            array('with-empty-value', ''),
+            array('with-missing', null),
+    	);
+    }
+
     public function testVeryDeepElementsTraversing()
     {
         $this->getSession()->visit($this->pathTo('/index.php'));

--- a/tests/Behat/Mink/Driver/web-fixtures/index.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/index.php
@@ -15,6 +15,13 @@
 <em>interesting</em>      text
         </div>
 
+        <div class="attribute-testing">
+            <input type="text" id="attr-elem[with-value]" with-value="some-value"/>
+            <input type="text" id="attr-elem[without-value]" without-value/>
+            <input type="text" id="attr-elem[with-empty-value]" with-empty-value=""/>
+            <input type="text" id="attr-elem[with-missing]"/>
+        </div>
+
         <div class="travers">
             <div class="sub">el1</div>
             <div class="sub">el2</div>


### PR DESCRIPTION
Each of a drivers (due various reasons) had to deal with bugs in underlying libraries. The common problem was, that a missing attribute value was returned as an empty string. To make output of `getAttribute` method consistent a workaround code was added that considered present attributes with empty values as missing ones.

Thus all attributes in following code were considered as missing:

``` html
<input disabled/>
<input disabled=""/>
```

I've implemented a series of PR's for all of the drivers to fix things:
- https://github.com/Behat/MinkSelenium2Driver/pull/89
- https://github.com/Behat/MinkSeleniumDriver/pull/18
- https://github.com/Behat/SahiClient/pull/12
- https://github.com/Behat/MinkBrowserKitDriver/pull/32

Since https://github.com/Behat/MinkGoutteDriver and https://github.com/Behat/MinkWUnitDriver are in fact extending https://github.com/Behat/MinkBrowserKitDriver, then no special PR's are needed for them.

This PR concludes work, related to `getAttribute` method fixing by adding a new test to check for all possible use cases.
