### PR TITLE
Attribute values asserted before page was opened

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -296,6 +296,8 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetAttribute($attributeName, $attributeValue)
     {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
         $element = $this->getSession()->getPage()->findById('attr-elem[' . $attributeName . ']');
 
         $this->assertSame($attributeValue, $element->getAttribute($attributeName));


### PR DESCRIPTION
Recently (see #398) I've added new tests to ensure, that `getAttribute` method works correctly. However I've forgot to add `->visit` at the beginning of test. This all worked because of driver base url (in tests) was set to `/index.php`, where HTML nodes for attribute testing were added.

To be on the safe side I've explicitly added `->visit` call.
