### PR TITLE
Improvement for window tests for JavaScript-only drivers

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -37,7 +37,10 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $page    = $session->getPage();
 
         $page->clickLink('Popup #1');
+        $session->switchToWindow(null);
+
         $page->clickLink('Popup #2');
+        $session->switchToWindow(null);
 
         $el = $page->find('css', '#text');
         $this->assertNotNull($el);

--- a/tests/Behat/Mink/Driver/web-fixtures/window.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/window.php
@@ -9,11 +9,11 @@ function newPopup(url, title) {
 }
 </script>
 
-<a href="javascript:newPopup('popup1.php', 'popup_1');">
+<a href="popup1.php" onclick="newPopup(this.href, 'popup_1'); return false;">
     Popup #1
 </a>
 
-<a href="javascript:newPopup('popup2.php', 'popup_2');">
+<a href="popup2.php" onclick="newPopup(this.href, 'popup_2'); return false;">
     Popup #2
 </a>
 


### PR DESCRIPTION
During my zombie reanimation project in https://github.com/Behat/MinkZombieDriver/pull/46 I've discovered, that since 2.0.0 version Zombie supports window management and that current window test fails because of:
1. focus isn't switched back to main window, after popup is opened
2. `javascript:` in `href` attribute of links scares Zombie and window content isn't retrieved

I've fixed all of above in this PR.
