### PR TITLE
Include `textarea` element in `testAdvancedForm` test

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -591,6 +591,7 @@ OUT
         $sex         = $page->findField('sex');
         $maillist    = $page->findField('mail_list');
         $agreement   = $page->findField('agreement');
+        $notes       = $page->findField('notes');
         $about       = $page->findField('about');
 
         $this->assertNotNull($firstname);
@@ -600,12 +601,14 @@ OUT
         $this->assertNotNull($sex);
         $this->assertNotNull($maillist);
         $this->assertNotNull($agreement);
+        $this->assertNotNull($notes);
 
         $this->assertEquals('Firstname', $firstname->getValue());
         $this->assertEquals('Lastname', $lastname->getValue());
         $this->assertEquals('your@email.com', $email->getValue());
         $this->assertEquals('20', $select->getValue());
         $this->assertEquals('w', $sex->getValue());
+        $this->assertEquals('original notes', $notes->getValue());
 
         $this->assertTrue($maillist->getValue());
         $this->assertFalse($agreement->getValue());
@@ -624,6 +627,9 @@ OUT
 
         $sex->selectOption('m');
         $this->assertEquals('m', $sex->getValue());
+
+        $notes->setValue('new notes');
+        $this->assertEquals('new notes', $notes->getValue());
 
         $about->attachFile($this->mapRemoteFilePath(__DIR__ . '/web-fixtures/some_file.txt'));
 
@@ -646,6 +652,7 @@ array (
   'email' = 'ever.zet@gmail.com',
   'first_name' = 'Foo "item"',
   'last_name' = 'Bar',
+  'notes' = 'new notes',
   'select_number' = '30',
   'sex' = 'm',
   'submit' = 'Register',

--- a/tests/Behat/Mink/Driver/web-fixtures/advanced_form.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/advanced_form.php
@@ -29,6 +29,8 @@
         <input type="checkbox" name="mail_list" checked="checked" value="on"/>
         <input type="checkbox" name="agreement" value="yes"/>
 
+        <textarea name="notes">original notes</textarea>
+
         <input type="file" name="about" />
 
         <input type="submit" name="submit" value="Register" />


### PR DESCRIPTION
The `setValue` and `getValue` methods are too complex in some drivers (e.g. in MinkZombieDriver), that `testAdvancedForm` exists to verify their correct behavior. It appears though `textarea` element isn't tested at all.

The problem was originally discovered in #215 issue (related to MinkSelenium2Driver) and test was added specifically for that driver instead of updating `testAdvancedForm`.
