### PR TITLE
Fixing PHPDoc’s to support object array auto-complete in IDE

### DIFF
--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -2,6 +2,7 @@
 
 namespace Behat\Mink\Driver;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 
 /*
@@ -172,7 +173,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return array array of NodeElements
+     * @return NodeElement[]
      */
     public function find($xpath);
 

--- a/src/Behat/Mink/Element/Element.php
+++ b/src/Behat/Mink/Element/Element.php
@@ -75,7 +75,7 @@ abstract class Element implements ElementInterface
      * @param string $selector selector engine name
      * @param string $locator  selector locator
      *
-     * @return array
+     * @return NodeElement[]
      */
     public function findAll($selector, $locator)
     {

--- a/src/Behat/Mink/Element/ElementInterface.php
+++ b/src/Behat/Mink/Element/ElementInterface.php
@@ -59,7 +59,7 @@ interface ElementInterface
      * @param string $selector selector engine name
      * @param string $locator  selector locator
      *
-     * @return array
+     * @return NodeElement[]
      */
     public function findAll($selector, $locator);
 

--- a/src/Behat/Mink/Mink.php
+++ b/src/Behat/Mink/Mink.php
@@ -26,7 +26,7 @@ class Mink
     /**
      * Initializes manager.
      *
-     * @param array $sessions
+     * @param Session[] $sessions
      */
     public function __construct(array $sessions = array())
     {

--- a/src/Behat/Mink/Selector/SelectorsHandler.php
+++ b/src/Behat/Mink/Selector/SelectorsHandler.php
@@ -24,7 +24,7 @@ class SelectorsHandler
     /**
      * Initializes selectors handler.
      *
-     * @param array $selectors default selectors to register
+     * @param SelectorInterface[] $selectors default selectors to register
      */
     public function __construct(array $selectors = array())
     {


### PR DESCRIPTION
I've updated several PHPDoc's to allow IDE's auto-complete for methods, that returns array of objects, like `findAll`.

Code example to enable auto-complete before this PR:

``` php
/** @var NodeElement $element */
foreach($page->findAll('css', 'input') as $element) {
// ...
}
```

After this PR no extra `@var` comment is needed to enable auto-complete in IDE.
