### PR TITLE
Set cookie to `/` path to please headless drivers

### DIFF
--- a/tests/Behat/Mink/Driver/web-fixtures/cookie_page1.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/cookie_page1.php
@@ -1,5 +1,5 @@
 <?php
-    setcookie('srvr_cookie', 'srv_var_is_set');
+    setcookie('srvr_cookie', 'srv_var_is_set', null, '/');
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru">


### PR DESCRIPTION
In headless drivers based on MinkBrowserKitDriver, like MinkGoutteDriver, the cookie manipulation code forces root path (`/`) to all cookie operations (set/get). This doesn't create any problems if only driver methods are used to work with cookies.

However, when in `testCookie` a cookie is set from PHP via `setcookie('srvr_cookie', 'srv_var_is_set');`, then according to http://php.net/manual/en/function.setcookie.php the path isn't `/` by default (as it is with MinkBrowserKitDriver), but is path from url to a file, where a cookie was set from.

Because of that cookie set by PHP from a script in a sub-folder can't be replaced/removed via MinkBrowserKitDriver `setCookie` method.

Actually MinkZombieDriver also stores cookie at `/` path, but when it comes to delete a cookie, then it removes it from all paths and that's why this test passes for it.
