### PR TITLE
Ensure, that all cookies are set to root path

### DIFF
--- a/tests/Behat/Mink/Driver/web-fixtures/issue140.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/issue140.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!empty($_POST)) {
-    setcookie ("tc", $_POST['cookie_value']);
+    setcookie ("tc", $_POST['cookie_value'], null, '/');
 } else if (isset($_GET["show_value"])) {
     echo $_COOKIE["tc"];
     die();


### PR DESCRIPTION
In #405 I've started to battle failing cookie tests in various drivers. This PR solves cookie being set in sub-folder problem for test, introduced in #140 issue. 
