### PR TITLE
Fix cross-browser inconsistency in text-case of NodeElement::getTagName() return

### DIFF
--- a/src/Behat/Mink/Element/NodeElement.php
+++ b/src/Behat/Mink/Element/NodeElement.php
@@ -63,7 +63,7 @@ class NodeElement extends TraversableElement
      */
     public function getTagName()
     {
-        return $this->getSession()->getDriver()->getTagName($this->getXpath());
+        return strtolower($this->getSession()->getDriver()->getTagName($this->getXpath()));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #428 |
| License | MIT |
| Doc PR | - |
### Test results

This passes the Mink tests.

It also makes more of the tests in MinkSelenium2Driver pass when using Safari, though I found that the pass rate was inconsistent. Even when switching back and forth between develop and my bugfix branch, alternating between the two branches on each test run, I had inconsistent results over many test runs.

Without the fix, I had 11-12 failures (see Behat/MinkSelenium2Driver#106). With the fix, I had 7-9 failures.

**Without the fix (highest failure rate - 12):**

```
There were 12 failures:

1) Tests\Behat\Mink\Driver\Selenium2DriverTest::testPatternGetWindowNames
Failed asserting that 'oa6lmd9hztd5' matches PCRE pattern "/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/".

Selenium2DriverTest.php:85

2) Tests\Behat\Mink\Driver\Selenium2DriverTest::testGetWindowName
Failed asserting that 'oa6lmd9hztd5' matches PCRE pattern "/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/".

Selenium2DriverTest.php:97

3) Tests\Behat\Mink\Driver\Selenium2DriverTest::testIssue140
Failed asserting that null matches expected 'some:value;'.

GeneralDriverTest.php:96

4) Tests\Behat\Mink\Driver\Selenium2DriverTest::testCookieWithPaths with data set #0 ('session_reset')
Failed asserting that 'Previous cookie: srv_var_is_set' contains "Previous cookie: NO".

GeneralDriverTest.php:186

5) Tests\Behat\Mink\Driver\Selenium2DriverTest::testCookieWithPaths with data set #1 ('cookie_delete')
Failed asserting that 'Previous cookie: srv_var_is_set' contains "Previous cookie: NO".

GeneralDriverTest.php:166

6) Tests\Behat\Mink\Driver\Selenium2DriverTest::testReset
Failed asserting that 'array ( 'foo' = 'bar', )' contains "array ( )".

GeneralDriverTest.php:240

7) Tests\Behat\Mink\Driver\Selenium2DriverTest::testElementsTraversing
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'h1'
+'H1'

GeneralDriverTest.php:306

8) Tests\Behat\Mink\Driver\Selenium2DriverTest::testMultiselect
Failed asserting that '10' matches expected '30'.

GeneralDriverTest.php:569

9) Tests\Behat\Mink\Driver\Selenium2DriverTest::testElementSelectedStateCheck with data set #0 ('select_number', '30', 'thirty')
Failed asserting that false is true.

GeneralDriverTest.php:610

10) Tests\Behat\Mink\Driver\Selenium2DriverTest::testElementSelectedStateCheck with data set #1 ('select_multiple_numbers[]', '2', 'two')
Failed asserting that false is true.

GeneralDriverTest.php:610

11) Tests\Behat\Mink\Driver\Selenium2DriverTest::testAdvancedForm
Failed asserting that '10' matches expected '30'.

GeneralDriverTest.php:680

12) Tests\Behat\Mink\Driver\Selenium2DriverTest::testAdvancedFormSecondSubmit
Failed asserting that '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru"><head>
    <title>ADvanced Form</title>
    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
</head>
<body>
    <h1>ADvanced Form Page</h1>

    <form method="POST" enctype="multipart/form-data" action="advanced_form_post.php">
        <input name="first_name" value="Firstname" type="text">
        <input id="lastn" name="last_name" value="Lastname" type="text">
        <label for="email">
            Your email:
            <input type="email" id="email" name="email" value="your@email.com">
        </label>

        <select name="select_number">
            <option value="10">ten</option>
            <option selected="selected" value="20">twenty</option>
            <option value="30">thirty</option>
        </select>

        <label for="sex">
            <span><input type="radio" name="sex" value="m"> m</span>
            <span><input type="radio" name="sex" value="w" checked="checked"> w</span>
        </label>

        <input type="checkbox" name="mail_list" checked="checked" value="on">
        <input type="checkbox" name="agreement" value="yes">

        <textarea name="notes">original notes</textarea>

        <input type="file" name="about">

        <input type="submit" name="submit" value="Register">
        <input type="submit" name="submit" value="Login">
    </form>


</body></html>' contains "'agreement' = 'off',".

GeneralDriverTest.php:830
```

**With the fix (lowest failure rate - 7):**

```
1) Tests\Behat\Mink\Driver\Selenium2DriverTest::testPatternGetWindowNames
Failed asserting that 'n0ijozmbq6kk' matches PCRE pattern "/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/".

Selenium2DriverTest.php:85

2) Tests\Behat\Mink\Driver\Selenium2DriverTest::testGetWindowName
Failed asserting that 'n0ijozmbq6kk' matches PCRE pattern "/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/".

Selenium2DriverTest.php:97

3) Tests\Behat\Mink\Driver\Selenium2DriverTest::testIssue140
Failed asserting that null matches expected 'some:value;'.

GeneralDriverTest.php:96

4) Tests\Behat\Mink\Driver\Selenium2DriverTest::testCookieWithPaths with data set #0 ('session_reset')
Failed asserting that 'Previous cookie: srv_var_is_set' contains "Previous cookie: NO".

GeneralDriverTest.php:186

5) Tests\Behat\Mink\Driver\Selenium2DriverTest::testCookieWithPaths with data set #1 ('cookie_delete')
Failed asserting that 'Previous cookie: srv_var_is_set' contains "Previous cookie: NO".

GeneralDriverTest.php:166

6) Tests\Behat\Mink\Driver\Selenium2DriverTest::testReset
Failed asserting that 'array ( 'foo' = 'bar', )' contains "array ( )".

GeneralDriverTest.php:240

7) Tests\Behat\Mink\Driver\Selenium2DriverTest::testAdvancedForm
Failed asserting that '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ru"><head>
    <title>Advanced form save</title>
    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
</head>
<body>
array (
  'agreement' = 'on',
  'email' = 'ever.zet@gmail.com',
  'first_name' = 'Foo "item"',
  'last_name' = 'Bar',
  'notes' = 'new notes',
  'select_number' = '30',
  'sex' = 'm',
  'submit' = 'Register',
)
no file

</body></html>' contains "array (
  'agreement' = 'on',
  'email' = 'ever.zet@gmail.com',
  'first_name' = 'Foo "item"',
  'last_name' = 'Bar',
  'notes' = 'new notes',
  'select_number' = '30',
  'sex' = 'm',
  'submit' = 'Register',
)
1 uploaded file".

GeneralDriverTest.php:715

```
