### PR TITLE
Change element location rule to evade Zombie error during form reset

### DIFF
--- a/tests/Behat/Mink/Driver/web-fixtures/basic_form.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/basic_form.php
@@ -11,8 +11,8 @@
         <input name="first_name" value="Firstname" type="text" />
         <input id="lastn" name="last_name" value="Lastname" type="text" />
 
-        <input type="reset" value="Reset" />
-        <input type="submit" value="Save" />
+        <input type="reset" id="Reset" />
+        <input type="submit" id="Save" />
     </form>
 </body>
 </html>


### PR DESCRIPTION
Fixes Behat/MinkZombieDriver#57.
