### PR TITLE
Mock SelectorsHandler in Element tests to break dependency on NamedSelector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
         "symfony/css-selector":  "~2.0"
     },
 
+    "require-dev": {
+        "mockery/mockery": "dev-master",
+        "phpunit/phpunit": "3.7.*"
+    },
+
     "suggest": {
         "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
         "behat/mink-goutte-driver":     "fast headless driver for any app without JS emulation",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,10 @@
         </testsuite>
     </testsuites>
 
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+    </listeners>
+
     <filter>
         <whitelist>
             <directory>./src/Behat/Mink/</directory>

--- a/tests/Behat/Mink/Element/DocumentElementTest.php
+++ b/tests/Behat/Mink/Element/DocumentElementTest.php
@@ -3,7 +3,10 @@
 namespace Test\Behat\Mink\Element;
 
 use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Selector\SelectorsHandler;
 use Behat\Mink\Session;
+use Mockery as m;
+use Mockery\MockInterface;
 
 require_once 'ElementTest.php';
 
@@ -13,13 +16,6 @@ require_once 'ElementTest.php';
 class DocumentElementTest extends ElementTest
 {
     /**
-     * Session.
-     *
-     * @var Session
-     */
-    private $session;
-
-    /**
      * Page.
      *
      * @var DocumentElement
@@ -28,7 +24,7 @@ class DocumentElementTest extends ElementTest
 
     protected function setUp()
     {
-        $this->session  = $this->getSessionWithMockedDriver();
+        parent::setUp();
         $this->document = new DocumentElement($this->session);
     }
 
@@ -40,42 +36,50 @@ class DocumentElementTest extends ElementTest
     public function testFindAll()
     {
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
+            ->shouldReceive('find')
             ->with('//html/h3[a]')
-            ->will($this->onConsecutiveCalls(array(2, 3, 4), array(1, 2), array()));
+            ->twice()
+            ->andReturn(array(2, 3, 4), array(1, 2), array());
 
-        $this->assertEquals(3, count($this->document->findAll('xpath', $xpath = 'h3[a]')));
+        $xpath = 'h3[a]';
+        $this->selectors->
+            shouldReceive('selectorToXpath')
+            ->with('xpath', $xpath)
+            ->once()
+            ->andReturn($xpath);
+        $this->assertEquals(3, count($this->document->findAll('xpath', $xpath)));
 
-        $selector = $this->getMockBuilder('Behat\Mink\Selector\SelectorInterface')->getMock();
-        $selector
-            ->expects($this->once())
-            ->method('translateToXPath')
-            ->with($css = 'h3 > a')
-            ->will($this->returnValue($xpath));
-
-        $this->session->getSelectorsHandler()->registerSelector('css', $selector);
+        $css = 'h3 > a';
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('css', $css)
+            ->once()
+            ->andReturn($xpath);
         $this->assertEquals(2, count($this->document->findAll('css', $css)));
     }
 
     public function testFind()
     {
         $this->session->getDriver()
-            ->expects($this->exactly(3))
-            ->method('find')
+            ->shouldReceive('find')
             ->with('//html/h3[a]')
-            ->will($this->onConsecutiveCalls(array(2, 3, 4), array(1, 2), array()));
+            ->times(3)
+            ->andReturn(array(2, 3, 4), array(1, 2), array());
 
-        $this->assertEquals(2, $this->document->find('xpath', $xpath = 'h3[a]'));
+        $xpath = 'h3[a]';
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('xpath', $xpath)
+            ->twice()
+            ->andReturn($xpath);
+        $this->assertEquals(2, $this->document->find('xpath', $xpath));
 
-        $selector = $this->getMockBuilder('Behat\Mink\Selector\SelectorInterface')->getMock();
-        $selector
-            ->expects($this->once())
-            ->method('translateToXPath')
-            ->with($css = 'h3 > a')
-            ->will($this->returnValue($xpath));
-
-        $this->session->getSelectorsHandler()->registerSelector('css', $selector);
+        $css = 'h3 > a';
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('css', $css)
+            ->once()
+            ->andReturn($xpath);
         $this->assertEquals(1, $this->document->find('css', $css));
 
         $this->assertNull($this->document->find('xpath', $xpath));
@@ -83,15 +87,11 @@ class DocumentElementTest extends ElementTest
 
     public function testFindField()
     {
-        $xpath = <<<XPATH
-//html/.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('field1', 'field2', 'field3'), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array('field1', 'field2', 'field3'),
+            array('field', 'some field')
+        );
 
         $this->assertEquals('field1', $this->document->findField('some field'));
         $this->assertEquals(null, $this->document->findField('some field'));
@@ -99,15 +99,11 @@ XPATH;
 
     public function testFindLink()
     {
-        $xpath = <<<XPATH
-//html/.//a[./@href][(((./@id = 'some link' or contains(normalize-space(string(.)), 'some link')) or contains(./@title, 'some link') or contains(./@rel, 'some link')) or .//img[contains(./@alt, 'some link')])] | .//*[./@role = 'link'][((./@id = 'some link' or contains(./@value, 'some link')) or contains(./@title, 'some link') or contains(normalize-space(string(.)), 'some link'))]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('link1', 'link2', 'link3'), array()));
+        $this->mockNamedFinder(
+            '//link',
+            array('link1', 'link2', 'link3'),
+            array('link', 'some link')
+        );
 
         $this->assertEquals('link1', $this->document->findLink('some link'));
         $this->assertEquals(null, $this->document->findLink('some link'));
@@ -115,15 +111,11 @@ XPATH;
 
     public function testFindButton()
     {
-        $xpath = <<<XPATH
-//html/.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button' or ./@type = 'reset'][(((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')] | .//button[((((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(normalize-space(string(.)), 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')] | .//*[./@role = 'button'][(((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(./@title, 'some button') or contains(normalize-space(string(.)), 'some button'))]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('button1', 'button2', 'button3'), array()));
+        $this->mockNamedFinder(
+            '//button',
+            array('button1', 'button2', 'button3'),
+            array('button', 'some button')
+        );
 
         $this->assertEquals('button1', $this->document->findButton('some button'));
         $this->assertEquals(null, $this->document->findButton('some button'));
@@ -131,15 +123,19 @@ XPATH;
 
     public function testFindById()
     {
-        $xpath = <<<XPATH
-//html//*[@id='some-item-2']
-XPATH;
+        $xpath = '//*[@id=some-item-2]';
 
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('id2', 'id3'), array()));
+            ->shouldReceive('find')
+            ->with('//html' . $xpath)
+            ->twice()
+            ->andReturn(array('id2', 'id3'), array());
+
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('xpath', $xpath)
+            ->twice()
+            ->andReturn($xpath);
 
         $this->assertEquals('id2', $this->document->findById('some-item-2'));
         $this->assertEquals(null, $this->document->findById('some-item-2'));
@@ -148,10 +144,16 @@ XPATH;
     public function testHasSelector()
     {
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
+            ->shouldReceive('find')
             ->with('//html/some xpath')
-            ->will($this->onConsecutiveCalls(array('id2', 'id3'), array()));
+            ->twice()
+            ->andReturn(array('id2', 'id3'), array());
+
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('xpath', 'some xpath')
+            ->twice()
+            ->andReturn('some xpath');
 
         $this->assertTrue($this->document->has('xpath', 'some xpath'));
         $this->assertFalse($this->document->has('xpath', 'some xpath'));
@@ -159,15 +161,11 @@ XPATH;
 
     public function testHasContent()
     {
-        $xpath = <<<XPATH
-//html/./descendant-or-self::*[contains(normalize-space(.), 'some content')]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('item1', 'item2'), array()));
+        $this->mockNamedFinder(
+            '//some content',
+            array('item1', 'item2'),
+            array('content', 'some content')
+        );
 
         $this->assertTrue($this->document->hasContent('some content'));
         $this->assertFalse($this->document->hasContent('some content'));
@@ -175,15 +173,11 @@ XPATH;
 
     public function testHasLink()
     {
-        $xpath = <<<XPATH
-//html/.//a[./@href][(((./@id = 'some link' or contains(normalize-space(string(.)), 'some link')) or contains(./@title, 'some link') or contains(./@rel, 'some link')) or .//img[contains(./@alt, 'some link')])] | .//*[./@role = 'link'][((./@id = 'some link' or contains(./@value, 'some link')) or contains(./@title, 'some link') or contains(normalize-space(string(.)), 'some link'))]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('link1', 'link2', 'link3'), array()));
+        $this->mockNamedFinder(
+            '//link',
+            array('link1', 'link2', 'link3'),
+            array('link', 'some link')
+        );
 
         $this->assertTrue($this->document->hasLink('some link'));
         $this->assertFalse($this->document->hasLink('some link'));
@@ -191,15 +185,11 @@ XPATH;
 
     public function testHasButton()
     {
-        $xpath = <<<XPATH
-//html/.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button' or ./@type = 'reset'][(((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')] | .//button[((((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(normalize-space(string(.)), 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')] | .//*[./@role = 'button'][(((./@id = 'some button' or ./@name = 'some button') or contains(./@value, 'some button')) or contains(./@title, 'some button') or contains(normalize-space(string(.)), 'some button'))]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('button1', 'button2', 'button3'), array()));
+        $this->mockNamedFinder(
+            '//button',
+            array('button1', 'button2', 'button3'),
+            array('button', 'some button')
+        );
 
         $this->assertTrue($this->document->hasButton('some button'));
         $this->assertFalse($this->document->hasButton('some button'));
@@ -207,15 +197,11 @@ XPATH;
 
     public function testHasField()
     {
-        $xpath = <<<XPATH
-//html/.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('field1', 'field2', 'field3'), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array('field1', 'field2', 'field3'),
+            array('field', 'some field')
+        );
 
         $this->assertTrue($this->document->hasField('some field'));
         $this->assertFalse($this->document->hasField('some field'));
@@ -223,22 +209,15 @@ XPATH;
 
     public function testHasCheckedField()
     {
-        $xpath = <<<XPATH
-//html/.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some checkbox' or ./@name = 'some checkbox') or ./@id = //label[contains(normalize-space(string(.)), 'some checkbox')]/@for) or ./@placeholder = 'some checkbox')] | .//label[contains(normalize-space(string(.)), 'some checkbox')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
-        $checkbox = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $checkbox
-            ->expects($this->exactly(2))
-            ->method('isChecked')
-            ->will($this->onConsecutiveCalls(true, false));
+        $checkbox = m::mock('Behat\Mink\Element\NodeElement');
+        $checkbox->shouldReceive('isChecked')->twice()->andReturn(true, false);
 
-        $this->session->getDriver()
-            ->expects($this->exactly(3))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array($checkbox), array(), array($checkbox)));
+        $this->mockNamedFinder(
+            '//field',
+            array(array($checkbox), array(), array($checkbox)),
+            array('field', 'some checkbox'),
+            3
+        );
 
         $this->assertTrue($this->document->hasCheckedField('some checkbox'));
         $this->assertFalse($this->document->hasCheckedField('some checkbox'));
@@ -247,22 +226,15 @@ XPATH;
 
     public function testHasUncheckedField()
     {
-        $xpath = <<<XPATH
-//html/.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some checkbox' or ./@name = 'some checkbox') or ./@id = //label[contains(normalize-space(string(.)), 'some checkbox')]/@for) or ./@placeholder = 'some checkbox')] | .//label[contains(normalize-space(string(.)), 'some checkbox')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
-        $checkbox = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $checkbox
-            ->expects($this->exactly(2))
-            ->method('isChecked')
-            ->will($this->onConsecutiveCalls(true, false));
+        $checkbox = m::mock('Behat\Mink\Element\NodeElement');
+        $checkbox->shouldReceive('isChecked')->twice()->andReturn(true, false);
 
-        $this->session->getDriver()
-            ->expects($this->exactly(3))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array($checkbox), array(), array($checkbox)));
+        $this->mockNamedFinder(
+            '//field',
+            array(array($checkbox), array(), array($checkbox)),
+            array('field', 'some checkbox'),
+            3
+        );
 
         $this->assertFalse($this->document->hasUncheckedField('some checkbox'));
         $this->assertFalse($this->document->hasUncheckedField('some checkbox'));
@@ -271,15 +243,11 @@ XPATH;
 
     public function testHasSelect()
     {
-        $xpath = <<<XPATH
-//html/.//select[(((./@id = 'some select field' or ./@name = 'some select field') or ./@id = //label[contains(normalize-space(string(.)), 'some select field')]/@for) or ./@placeholder = 'some select field')] | .//label[contains(normalize-space(string(.)), 'some select field')]//.//select
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('select'), array()));
+        $this->mockNamedFinder(
+            '//select',
+            array('select'),
+            array('select', 'some select field')
+        );
 
         $this->assertTrue($this->document->hasSelect('some select field'));
         $this->assertFalse($this->document->hasSelect('some select field'));
@@ -287,15 +255,11 @@ XPATH;
 
     public function testHasTable()
     {
-        $xpath = <<<XPATH
-//html/.//table[(./@id = 'some table' or contains(.//caption, 'some table'))]
-XPATH;
-
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->with($xpath)
-            ->will($this->onConsecutiveCalls(array('table'), array()));
+        $this->mockNamedFinder(
+            '//table',
+            array('table'),
+            array('table', 'some table')
+        );
 
         $this->assertTrue($this->document->hasTable('some table'));
         $this->assertFalse($this->document->hasTable('some table'));
@@ -303,20 +267,14 @@ XPATH;
 
     public function testClickLink()
     {
-        $xpath = <<<XPATH
-//html/.//a[./@href][(((./@id = 'some link' or contains(normalize-space(string(.)), 'some link')) or contains(./@title, 'some link')) or .//img[contains(./@alt, 'some link')])]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('click')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('click');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//link',
+            array($node),
+            array('link', 'some link')
+        );
 
         $this->document->clickLink('some link');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -325,20 +283,14 @@ XPATH;
 
     public function testClickButton()
     {
-        $xpath = <<<XPATH
-//html/.//input[./@type = 'submit' or ./@type = 'image' or ./@type = 'button'][((./@id = 'some button' or contains(./@value, 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')] | .//button[(((./@id = 'some button' or contains(./@value, 'some button')) or contains(normalize-space(string(.)), 'some button')) or contains(./@title, 'some button'))] | .//input[./@type = 'image'][contains(./@alt, 'some button')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('press')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('press');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//button',
+            array($node),
+            array('button', 'some button')
+        );
 
         $this->document->pressButton('some button');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -347,21 +299,14 @@ XPATH;
 
     public function testFillField()
     {
-        $xpath = <<<XPATH
-.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('setValue')->with('some val')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('setValue')
-            ->with('some val');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
 
         $this->document->fillField('some field', 'some val');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -370,20 +315,14 @@ XPATH;
 
     public function testCheckField()
     {
-        $xpath = <<<XPATH
-.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('check')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('check');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
 
         $this->document->checkField('some field');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -392,20 +331,14 @@ XPATH;
 
     public function testUncheckField()
     {
-        $xpath = <<<XPATH
-.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('uncheck')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('uncheck');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
 
         $this->document->uncheckField('some field');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -414,21 +347,14 @@ XPATH;
 
     public function testSelectField()
     {
-        $xpath = <<<XPATH
-.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('selectOption')->with('option2', false)->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('selectOption')
-            ->with('option2');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
 
         $this->document->selectFieldOption('some field', 'option2');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -437,21 +363,14 @@ XPATH;
 
     public function testAttachFileToField()
     {
-        $xpath = <<<XPATH
-.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')][(((./@id = 'some field' or ./@name = 'some field') or ./@id = //label[contains(normalize-space(string(.)), 'some field')]/@for) or ./@placeholder = 'some field')] | .//label[contains(normalize-space(string(.)), 'some field')]//.//*[self::input | self::textarea | self::select][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')]
-XPATH;
+        $node = m::mock('Behat\Mink\Element\NodeElement');
+        $node->shouldReceive('attachFile')->with('/path/to/file')->once();
 
-        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $node
-            ->expects($this->once())
-            ->method('attachFile')
-            ->with('/path/to/file');
-        $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('find')
-            ->will($this->onConsecutiveCalls(array($node), array()));
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
 
         $this->document->attachFileToField('some field', '/path/to/file');
         $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
@@ -460,22 +379,24 @@ XPATH;
 
     public function testGetContent()
     {
+        $expects = 'page content';
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getContent')
-            ->will($this->returnValue($ret = 'page content'));
+            ->shouldReceive('getContent')
+            ->once()
+            ->andReturn($expects);
 
-        $this->assertEquals($ret, $this->document->getContent());
+        $this->assertEquals($expects, $this->document->getContent());
     }
 
     public function testGetText()
     {
+        $expects = 'val1';
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getText')
+            ->shouldReceive('getText')
             ->with('//html')
-            ->will($this->returnValue('val1'));
+            ->once()
+            ->andReturn($expects);
 
-        $this->assertEquals('val1', $this->document->getText());
+        $this->assertEquals($expects, $this->document->getText());
     }
 }

--- a/tests/Behat/Mink/Element/ElementTest.php
+++ b/tests/Behat/Mink/Element/ElementTest.php
@@ -2,20 +2,67 @@
 
 namespace Test\Behat\Mink\Element;
 
-use Behat\Mink\Session;
 use Behat\Mink\Selector\SelectorsHandler;
+use Behat\Mink\Session;
+use Mockery as m;
+use Mockery\MockInterface;
 
 /**
  * @group unittest
  */
 abstract class ElementTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Session.
+     *
+     * @var Session
+     */
+    protected $session;
+
+    /**
+     * Selectors.
+     *
+     * @var SelectorsHandler|MockInterface
+     */
+    protected $selectors;
+
+    protected function setUp()
+    {
+        $this->session  = $this->getSessionWithMockedDriver();
+        $this->selectors = $this->session->getSelectorsHandler();
+    }
+
     protected function getSessionWithMockedDriver()
     {
-        $driver     = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
-        $selectors  = new SelectorsHandler();
-        $session    = new Session($driver, $selectors);
+        $driver = m::mock('Behat\Mink\Driver\DriverInterface');
+        $driver->shouldReceive('setSession')->once();
+
+        $selectors = m::mock('Behat\Mink\Selector\SelectorsHandler');
+        $session = new Session($driver, $selectors);
+
+        $selectors->shouldReceive('xpathLiteral')->andReturnUsing(function ($s) {
+            return $s;
+        });
 
         return $session;
+    }
+
+    protected function mockNamedFinder($xpath, array $results, $locator, $times = 2)
+    {
+        if (!is_array($results[0])) {
+            $results = array($results, array());
+        }
+
+        $this->session->getDriver()
+            ->shouldReceive('find')
+            ->with('//html' . $xpath)
+            ->times($times)
+            ->andReturnValues($results);
+
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('named', $locator)
+            ->times($times)
+            ->andReturn($xpath);
     }
 }

--- a/tests/Behat/Mink/Element/NodeElementTest.php
+++ b/tests/Behat/Mink/Element/NodeElementTest.php
@@ -3,7 +3,7 @@
 namespace Test\Behat\Mink\Element;
 
 use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Session;
+use Mockery as m;
 
 require_once 'ElementTest.php';
 
@@ -12,17 +12,6 @@ require_once 'ElementTest.php';
  */
 class NodeElementTest extends ElementTest
 {
-    /**
-     * Session.
-     *
-     * @var Session
-     */
-    private $session;
-
-    protected function setUp()
-    {
-        $this->session = $this->getSessionWithMockedDriver();
-    }
 
     public function testGetXpath()
     {
@@ -34,15 +23,16 @@ class NodeElementTest extends ElementTest
 
     public function testGetText()
     {
+        $expected = 'val1';
         $node = new NodeElement('text_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getText')
+            ->shouldReceive('getText')
             ->with('text_tag')
-            ->will($this->returnValue('val1'));
+            ->once()
+            ->andReturn($expected);
 
-        $this->assertEquals('val1', $node->getText());
+        $this->assertEquals($expected, $node->getText());
     }
 
     public function testHasAttribute()
@@ -50,10 +40,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('input_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('getAttribute')
+            ->shouldReceive('getAttribute')
             ->with('input_tag', 'href')
-            ->will($this->onConsecutiveCalls(null, 'http://...'));
+            ->twice()
+            ->andReturn(null, 'http://...');
 
         $this->assertFalse($node->hasAttribute('href'));
         $this->assertTrue($node->hasAttribute('href'));
@@ -64,10 +54,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('input_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getAttribute')
+            ->shouldReceive('getAttribute')
             ->with('input_tag', 'href')
-            ->will($this->returnValue('http://...'));
+            ->once()
+            ->andReturn('http://...');
 
         $this->assertEquals('http://...', $node->getAttribute('href'));
     }
@@ -77,10 +67,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('input_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->exactly(6))
-            ->method('getAttribute')
+            ->shouldReceive('getAttribute')
             ->with('input_tag', 'class')
-            ->will($this->returnValue('class1 class2'));
+            ->times(6)
+            ->andReturn('class1 class2');
 
         $this->assertTrue($node->hasClass('class1'));
         $this->assertTrue($node->hasClass('class2'));
@@ -89,27 +79,29 @@ class NodeElementTest extends ElementTest
 
     public function testGetValue()
     {
+        $expected = 'val1';
         $node = new NodeElement('input_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getValue')
+            ->shouldReceive('getValue')
             ->with('input_tag')
-            ->will($this->returnValue('val1'));
+            ->once()
+            ->andReturn($expected);
 
-        $this->assertEquals('val1', $node->getValue());
+        $this->assertEquals($expected, $node->getValue());
     }
 
     public function testSetValue()
     {
+        $expected = 'new_val';
         $node = new NodeElement('input_tag', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('setValue')
-            ->with('input_tag', 'new_val');
+            ->shouldReceive('setValue')
+            ->with('input_tag', $expected)
+            ->once();
 
-        $node->setValue('new_val');
+        $node->setValue($expected);
     }
 
     public function testClick()
@@ -117,9 +109,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('link_or_button', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('click')
-            ->with('link_or_button');
+            ->shouldReceive('click')
+            ->with('link_or_button')
+            ->once();
 
         $node->click();
     }
@@ -129,9 +121,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('elem', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('rightClick')
-            ->with('elem');
+            ->shouldReceive('rightClick')
+            ->with('elem')
+            ->once();
 
         $node->rightClick();
     }
@@ -141,9 +133,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('elem', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('doubleClick')
-            ->with('elem');
+            ->shouldReceive('doubleClick')
+            ->with('elem')
+            ->once();
 
         $node->doubleClick();
     }
@@ -153,9 +145,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('checkbox_or_radio', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('check')
-            ->with('checkbox_or_radio');
+            ->shouldReceive('check')
+            ->with('checkbox_or_radio')
+            ->once();
 
         $node->check();
     }
@@ -165,9 +157,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('checkbox_or_radio', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('uncheck')
-            ->with('checkbox_or_radio');
+            ->shouldReceive('uncheck')
+            ->with('checkbox_or_radio')
+            ->once();
 
         $node->uncheck();
     }
@@ -175,11 +167,31 @@ class NodeElementTest extends ElementTest
     public function testSelectOption()
     {
         $node = new NodeElement('select', $this->session);
+        $option = m::mock('Behat\Mink\Element\NodeElement');
+        $option->shouldReceive('getValue')->once()->andReturn('item1');
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('selectOption')
-            ->with('select', 'item1');
+            ->shouldReceive('getTagName')
+            ->with('select')
+            ->once()
+            ->andReturn('select');
+
+        $this->session->getDriver()
+            ->shouldReceive('find')
+            ->with('select/option')
+            ->once()
+            ->andReturn(array($option));
+
+        $this->selectors
+            ->shouldReceive('selectorToXpath')
+            ->with('named', array('option', 'item1'))
+            ->once()
+            ->andReturn('option');
+
+        $this->session->getDriver()
+            ->shouldReceive('selectOption')
+            ->with('select', 'item1', false)
+            ->once();
 
         $node->selectOption('item1');
     }
@@ -189,10 +201,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('html//h3', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('getTagName')
+            ->shouldReceive('getTagName')
             ->with('html//h3')
-            ->will($this->returnValue('h3'));
+            ->once()
+            ->andReturn('h3');
 
         $this->assertEquals('h3', $node->getTagName());
     }
@@ -202,10 +214,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some_xpath', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('isVisible')
+            ->shouldReceive('isVisible')
             ->with('some_xpath')
-            ->will($this->onConsecutiveCalls(true, false));
+            ->twice()
+            ->andReturn(true, false);
 
         $this->assertTrue($node->isVisible());
         $this->assertFalse($node->isVisible());
@@ -216,10 +228,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some_xpath', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('isChecked')
+            ->shouldReceive('isChecked')
             ->with('some_xpath')
-            ->will($this->onConsecutiveCalls(true, false));
+            ->twice()
+            ->andReturn(true, false);
 
         $this->assertTrue($node->isChecked());
         $this->assertFalse($node->isChecked());
@@ -230,10 +242,10 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some_xpath', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->exactly(2))
-            ->method('isSelected')
+            ->shouldReceive('isSelected')
             ->with('some_xpath')
-            ->will($this->onConsecutiveCalls(true, false));
+            ->twice()
+            ->andReturn(true, false);
 
         $this->assertTrue($node->isSelected());
         $this->assertFalse($node->isSelected());
@@ -244,9 +256,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some-element', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('focus')
-            ->with('some-element');
+            ->shouldReceive('focus')
+            ->with('some-element')
+            ->once();
 
         $node->focus();
     }
@@ -256,9 +268,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some-element', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('blur')
-            ->with('some-element');
+            ->shouldReceive('blur')
+            ->with('some-element')
+            ->once();
 
         $node->blur();
     }
@@ -268,9 +280,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some-element', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('mouseOver')
-            ->with('some-element');
+            ->shouldReceive('mouseOver')
+            ->with('some-element')
+            ->once();
 
         $node->mouseOver();
     }
@@ -280,9 +292,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some_tag1', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('triggerEvent')
-            ->with('some_tag1', 'some_tag3');
+            ->shouldReceive('triggerEvent')
+            ->with('some_tag1', 'some_tag3')
+            ->once();
 
         $node->dragTo(new NodeElement('some_tag2', $this->session));
     }
@@ -292,9 +304,9 @@ class NodeElementTest extends ElementTest
         $node = new NodeElement('some_xpath', $this->session);
 
         $this->session->getDriver()
-            ->expects($this->once())
-            ->method('submitForm')
-            ->with('some_xpath');
+            ->shouldReceive('submitForm')
+            ->with('some_xpath')
+            ->once();
 
         $node->submit();
     }


### PR DESCRIPTION
1. connecting Mockery
2. using Mockery to create mocks in affected tests

Fixes #436
