### PR TITLE
Adding tests to cover all xpath-related matching logic in NamedSelector

### DIFF
--- a/tests/Behat/Mink/Selector/NamedSelectorTest.php
+++ b/tests/Behat/Mink/Selector/NamedSelectorTest.php
@@ -46,12 +46,87 @@ class NamedSelectorTest extends \PHPUnit_Framework_TestCase
 
     public function getSelectorTests()
     {
+        $fieldCount = 12; // fields without `type` attribute
+        $fieldCount += 4; // fields with `type=checkbox` attribute
+        $fieldCount += 4; // fields with `type=radio` attribute
+        $fieldCount += 4; // fields with `type=file` attribute
+
         // Fixture file,  selector name,  locator,  expected number of matched elements
+
         return array(
-            'link' => array('test.html', 'link', 'link', 5),
-            'link not found' => array('test.html', 'link', 'Not found', 0),
-            'button' => array('test.html', 'button', 'Send', 19),
-            'link or button' => array('test.html', 'link_or_button', 'Something else', 2),
+            'fieldset' => array('test.html', 'fieldset', 'fieldset-text', 2),
+
+            'field (name/placeholder/label)' => array('test.html', 'field', 'the-field', $fieldCount),
+            'field (input, with-id)' => array('test.html', 'field', 'the-field-input', 1),
+            'field (textarea, with-id)' => array('test.html', 'field', 'the-field-textarea', 1),
+            'field (select, with-id)' => array('test.html', 'field', 'the-field-select', 1),
+            'field (input type=submit, with-id) ignored' => array('test.html', 'field', 'the-field-submit-button', 0),
+            'field (input type=image, with-id) ignored' => array('test.html', 'field', 'the-field-image-button', 0),
+            'field (input type=hidden, with-id) ignored' => array('test.html', 'field', 'the-field-hidden', 0),
+
+            'link (with-href)' => array('test.html', 'link', 'link-text', 5),
+            'link (without-href) ignored' => array('test.html', 'link', 'bad-link-text', 0),
+            'link* (role=link)' => array('test.html', 'link', 'link-role-text', 4),
+
+            'button (input, name/value/title)' => array('test.html', 'button', 'button-text', 25),
+            'button (type=image, with-alt)' => array('test.html', 'button', 'button-alt-text', 1),
+            'button (input type=submit, with-id)' => array('test.html', 'button', 'input-submit-button', 1),
+            'button (input type=image, with-id)' => array('test.html', 'button', 'input-image-button', 1),
+            'button (input type=button, with-id)' => array('test.html', 'button', 'input-button-button', 1),
+            'button (input type=reset, with-id)' => array('test.html', 'button', 'input-reset-button', 1),
+            'button (button type=submit, with-id)' => array('test.html', 'button', 'button-submit-button', 1),
+            'button (button type=image, with-id)' => array('test.html', 'button', 'button-image-button', 1),
+            'button (button type=button, with-id)' => array('test.html', 'button', 'button-button-button', 1),
+            'button (button type=reset, with-id)' => array('test.html', 'button', 'button-reset-button', 1),
+            'button* (role=button, name/value/title)' => array('test.html', 'button', 'button-role-text', 12),
+            'button* (role=button type=submit, with-id)' => array('test.html', 'button', 'role-button-submit-button', 1),
+            'button* (role=button type=image, with-id)' => array('test.html', 'button', 'role-button-image-button', 1),
+            'button* (role=button type=button, with-id)' => array('test.html', 'button', 'role-button-button-button', 1),
+            'button* (role=button type=reset, with-id)' => array('test.html', 'button', 'role-button-reset-button', 1),
+
+            'link_or_button (with-href)' => array('test.html', 'link_or_button', 'link-text', 5),
+            'link_or_button (without-href) ignored' => array('test.html', 'link_or_button', 'bad-link-text', 0),
+            'link_or_button* (role=link)' => array('test.html', 'link_or_button', 'link-role-text', 4),
+
+            // bug in selector: 17 instead of 25, because 8 buttons with `name` attribute were not matched
+            'link_or_button (input, name/value/title)' => array('test.html', 'link_or_button', 'button-text', 17),
+            'link_or_button (type=image, with-alt)' => array('test.html', 'link_or_button', 'button-alt-text', 1),
+            'link_or_button (input type=submit, with-id)' => array('test.html', 'link_or_button', 'input-submit-button', 1),
+            'link_or_button (input type=image, with-id)' => array('test.html', 'link_or_button', 'input-image-button', 1),
+            'link_or_button (input type=button, with-id)' => array('test.html', 'link_or_button', 'input-button-button', 1),
+            'link_or_button (input type=reset, with-id)' => array('test.html', 'link_or_button', 'input-reset-button', 1),
+            'link_or_button (button type=submit, with-id)' => array('test.html', 'link_or_button', 'button-submit-button', 1),
+            'link_or_button (button type=image, with-id)' => array('test.html', 'link_or_button', 'button-image-button', 1),
+            'link_or_button (button type=button, with-id)' => array('test.html', 'link_or_button', 'button-button-button', 1),
+            'link_or_button (button type=reset, with-id)' => array('test.html', 'link_or_button', 'button-reset-button', 1),
+
+            // bug in selector: 8 instead of 12, because 4 buttons with `name` attribute were not matched
+            'link_or_button* (role=button, name/value/title)' => array('test.html', 'link_or_button', 'button-role-text', 8),
+            'link_or_button* (role=button type=submit, with-id)' => array('test.html', 'link_or_button', 'role-button-submit-button', 1),
+            'link_or_button* (role=button type=image, with-id)' => array('test.html', 'link_or_button', 'role-button-image-button', 1),
+            'link_or_button* (role=button type=button, with-id)' => array('test.html', 'link_or_button', 'role-button-button-button', 1),
+            'link_or_button* (role=button type=reset, with-id)' => array('test.html', 'link_or_button', 'role-button-reset-button', 1),
+
+            // 3 matches, because matches every HTML node in path: html > body > div
+            'content' => array('test.html', 'content', 'content-text', 3),
+
+            'select (name/placeholder/label)' => array('test.html', 'select', 'the-field', 4),
+            'select (with-id)' => array('test.html', 'select', 'the-field-select', 1),
+
+            'checkbox (name/placeholder/label)' => array('test.html', 'checkbox', 'the-field', 4),
+            'checkbox (with-id)' => array('test.html', 'checkbox', 'the-field-checkbox', 1),
+
+            'radio (name/placeholder/label)' => array('test.html', 'radio', 'the-field', 4),
+            'radio (with-id)' => array('test.html', 'radio', 'the-field-radio', 1),
+
+            'file (name/placeholder/label)' => array('test.html', 'file', 'the-field', 4),
+            'file (with-id)' => array('test.html', 'file', 'the-field-file', 1),
+
+            'optgroup' => array('test.html', 'optgroup', 'group-label', 1),
+
+            'option' => array('test.html', 'option', 'option-value', 2),
+
+            'table' => array('test.html', 'table', 'the-table', 2),
         );
     }
 }

--- a/tests/Behat/Mink/Selector/fixtures/test.html
+++ b/tests/Behat/Mink/Selector/fixtures/test.html
@@ -4,40 +4,233 @@
     <title></title>
 </head>
 <body>
-<p id="test">
-    <a href="" id="link"></a>
-    <a href="" title="Send">link</a>
-    <a href="" rel="link"></a>
-    <a href="" title="link"></a>
-    <a href=""><img src="" alt="link"></a>
-    <a>link</a>
-    <a href="" title="other" rel="Send">Something else</a>
-</p>
-<form>
-    <!-- Buttons -->
-    <input type="submit" value="Send" id="submit-input">
-    <input type="reset" value="Send" id="reset-input">
-    <input type="image" value="Send" id="image-input">
-    <input type="button" value="Send" id="button-input">
-    <input type="submit" id="Send">
-    <input type="submit" name="Send">
-    <input type="reset" name="Send">
-    <input type="image" name="Send">
-    <input type="button" name="Send">
-    <input type="submit" title="Send">
-    <input type="reset" title="Send">
-    <input type="image" title="Send">
-    <input type="button" title="Send">
+    <div id="test-for-link-selector">
+        <!-- match links with `href` attribute -->
+        <a href="#" id="link-text"></a>
+        <a href="#">some link-text</a>
+        <a href="#" title="some link-text"></a>
+        <a href="#" rel="some link-text"></a>
+        <a href="#">
+            <img src="#" alt="some link-text"/>
+        </a>
 
-    <button id="submit-button">Send</button>
-    <button value="Send">Other</button>
-    <button title="Send"></button>
-    <button name="Send"></button>
-    <a role="button">Send</a>
-    <a role="button" title="Send"></a>
+        <!-- don't match links without `href` attribute -->
+        <a id="bad-link-text"></a>
+        <a>some bad-link-text</a>
+        <a title="some bad-link-text"></a>
+        <a rel="some bad-link-text"></a>
+        <a>
+            <img src="#" alt="some bad-link-text"/>
+        </a>
 
-    <button>Something else</button>
-    <input type="hidden" value="Send">
-</form>
+        <!-- match links with `role=link` attribute -->
+        <span role="link" id="link-role-text"></span>
+        <span role="link" value="some link-role-text"></span>
+        <span role="link" title="some link-role-text"></span>
+        <span role="link">some link-role-text</span>
+    </div>
+
+    <div id="test-for-fieldset-selector">
+        <!-- match fieldsets -->
+        <fieldset id="fieldset-text"></fieldset>
+
+        <fieldset>
+            <legend>fieldset-text sample</legend>
+        </fieldset>
+
+        <!-- don't match fieldsets -->
+        <fieldset>fieldset-text sample</fieldset>
+        <fieldset></fieldset>
+    </div>
+
+    <div id="test-for-content-selector">
+        some content-text
+    </div>
+
+    <form>
+        <div id="test-for-field-selector">
+            <!-- match fields by `id` attribute -->
+            <input id="the-field-input"/>
+            <textarea id="the-field-textarea"></textarea>
+            <select id="the-field-select"></select>
+
+            <!-- match fields by `name` attribute -->
+            <input name="the-field"/>
+            <textarea name="the-field"></textarea>
+            <select name="the-field"></select>
+
+            <!-- match fields by `placeholder` attribute -->
+            <input placeholder="the-field"/>
+            <textarea placeholder="the-field"></textarea>
+            <select placeholder="the-field"></select>
+
+            <!-- match fields by associated label -->
+            <label for="label-for-input">the-field</label><input id="label-for-input"/>
+            <label for="label-for-textarea">the-field</label><textarea id="label-for-textarea"></textarea>
+            <label for="label-for-select">the-field</label><select id="label-for-select"></select>
+
+            <!-- match fields, surrounded by matching label -->
+            <label>the-field<input/></label>
+            <label>the-field<textarea></textarea></label>
+            <label>the-field<select></select></label>
+
+            <!-- don't match fields by `id` attribute -->
+            <input type="submit" id="the-field-submit-button"/>
+            <input type="image" id="the-field-image-button"/>
+            <input type="hidden" id="the-field-hidden"/>
+
+            <!-- don't match fields by `name` attribute -->
+            <input type="submit" name="the-field"/>
+            <input type="image" name="the-field"/>
+            <input type="hidden" name="the-field"/>
+
+            <!-- don't match fields by `placeholder` attribute -->
+            <input type="submit" placeholder="the-field"/>
+            <input type="image" placeholder="the-field"/>
+            <input type="hidden" placeholder="the-field"/>
+
+            <!-- don't match fields by associated label -->
+            <label for="label-for-the-field-submit-button">the-field</label><input type="submit" id="label-for-the-field-submit-button"/>
+            <label for="label-for-the-field-image-button">the-field</label><input type="image" id="label-for-the-field-image-button"/>
+            <label for="label-for-the-field-hidden">the-field</label><input type="hidden" id="label-for-the-field-hidden"/>
+
+            <!-- don't match fields, surrounded by matching label -->
+            <label>the-field<input type="submit"/></label>
+            <label>the-field<input type="image"/></label>
+            <label>the-field<input type="hidden"/></label>
+        </div>
+
+        <div id="test-for-button-selector">
+            <!-- match buttons by `id` attribute -->
+            <input type="submit" id="input-submit-button"/>
+            <input type="image" id="input-image-button"/>
+            <input type="button" id="input-button-button"/>
+            <input type="reset" id="input-reset-button"/>
+
+            <button type="submit" id="button-submit-button"></button>
+            <button type="image" id="button-image-button"></button>
+            <button type="button" id="button-button-button"></button>
+            <button type="reset" id="button-reset-button"></button>
+
+            <!-- match buttons by `name` attribute -->
+            <input type="submit" name="button-text"/>
+            <input type="image" name="button-text"/>
+            <input type="button" name="button-text"/>
+            <input type="reset" name="button-text"/>
+            <button type="submit" name="button-text"></button>
+            <button type="image" name="button-text"></button>
+            <button type="button" name="button-text"></button>
+            <button type="reset" name="button-text"></button>
+
+            <!-- match buttons by `value` attribute -->
+            <input type="submit" value="some button-text"/>
+            <input type="image" value="some button-text"/>
+            <input type="button" value="some button-text"/>
+            <input type="reset" value="some button-text"/>
+            <button type="submit" value="some button-text"></button>
+            <button type="image" value="some button-text"></button>
+            <button type="button" value="some button-text"></button>
+            <button type="reset" value="some button-text"></button>
+
+            <!-- match buttons by `title` attribute -->
+            <input type="submit" title="some button-text"/>
+            <input type="image" title="some button-text"/>
+            <input type="button" title="some button-text"/>
+            <input type="reset" title="some button-text"/>
+            <button type="submit" title="some button-text"></button>
+            <button type="image" title="some button-text"></button>
+            <button type="button" title="some button-text"></button>
+            <button type="reset" title="some button-text"></button>
+
+            <!-- match some buttons by `alt` attribute -->
+            <input type="submit" alt="some button-alt-text"/>
+            <input type="image" alt="some button-alt-text"/>
+            <input type="button" alt="some button-alt-text"/>
+            <input type="reset" alt="some button-alt-text"/>
+
+            <!-- match by `button` text -->
+            <button>some button-text</button>
+
+            <!-- match buttons with `role=button` & `id` attribute -->
+            <span role="button" type="submit" id="role-button-submit-button"></span>
+            <span role="button" type="image" id="role-button-image-button"></span>
+            <span role="button" type="button" id="role-button-button-button"></span>
+            <span role="button" type="reset" id="role-button-reset-button"></span>
+
+            <!-- match buttons with `role=button` & `name` attribute -->
+            <span role="button" type="submit" name="button-role-text"></span>
+            <span role="button" type="image" name="button-role-text"></span>
+            <span role="button" type="button" name="button-role-text"></span>
+            <span role="button" type="reset" name="button-role-text"></span>
+
+            <!-- match buttons with `role=button` & `value` attribute -->
+            <span role="button" type="submit" value="some button-role-text"></span>
+            <span role="button" type="image" value="some button-role-text"></span>
+            <span role="button" type="button" value="some button-role-text"></span>
+            <span role="button" type="reset" value="some button-role-text"></span>
+
+            <!-- match buttons with `role=button` & `title` attribute -->
+            <span role="button" type="submit" title="some button-role-text"></span>
+            <span role="button" type="image" title="some button-role-text"></span>
+            <span role="button" type="button" title="some button-role-text"></span>
+            <span role="button" type="reset" title="some button-role-text"></span>
+        </div>
+
+        <div id="test-for-checkbox-selector">
+            <input type="checkbox" id="the-field-checkbox"/>
+            <input type="checkbox" name="the-field"/>
+            <input type="checkbox" placeholder="the-field"/>
+            <label for="label-for-checkbox">the-field</label><input type="checkbox" id="label-for-checkbox"/>
+            <label>the-field<input type="checkbox"/></label>
+        </div>
+
+        <div id="test-for-radio-selector">
+            <input type="radio" id="the-field-radio"/>
+            <input type="radio" name="the-field"/>
+            <input type="radio" placeholder="the-field"/>
+            <label for="label-for-radio">the-field</label><input type="radio" id="label-for-radio"/>
+            <label>the-field<input type="radio"/></label>
+        </div>
+
+        <div id="test-for-file-selector">
+            <input type="file" id="the-field-file"/>
+            <input type="file" name="the-field"/>
+            <input type="file" placeholder="the-field"/>
+            <label for="label-for-file">the-field</label><input type="file" id="label-for-file"/>
+            <label>the-field<input type="file"/></label>
+        </div>
+
+        <div id="test-for-select-related-stuff">
+            <!-- match select stuff -->
+            <select name="the-select-stuff-test">
+                <optgroup label="some group-label">
+                    <option value="option-value"></option>
+                </optgroup>
+                <option value="">some option-value</option>
+            </select>
+
+            <!-- don't match select stuff -->
+            <select name="the-select-stuff-test">
+                <optgroup label="">some group-label</optgroup>
+                <option value="some option-value"></option>
+            </select>
+        </div>
+    </form>
+
+    <div id="test-for-table-selector">
+        <!-- match tables -->
+        <table id="the-table"></table>
+        <table>
+            <caption>some the-table</caption>
+        </table>
+
+        <!-- don't match tables -->
+        <table>
+            <tr>
+                <th>the-table</th>
+                <td>the-table</td>
+            </tr>
+        </table>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Added tests cover 100% of elements, that `NamedSelector` can match right now. Together with #438 it will convert `NamedSelector` into a class, that people can easily contribute to without risking in breaking any of xpaths by accident.

Fixes #437
