### PR TITLE
Fixing inconsistencies in NamedSelector xpath expressions

### DIFF
--- a/src/Behat/Mink/Selector/NamedSelector.php
+++ b/src/Behat/Mink/Selector/NamedSelector.php
@@ -32,7 +32,7 @@ class NamedSelector implements SelectorInterface
         // complex replacements
         '%fieldMatch%' => '(%idOrNameMatch% or %labelTextMatch% or %placeholderMatch%)',
         '%fieldFilter%' => 'self::input | self::textarea | self::select',
-        '%notFieldTypeFilter%' => "not(./@type = 'submit' or ./@type = 'image' or ./@type = 'hidden')",
+        '%notFieldTypeFilter%' => "not(%buttonTypeFilter% or ./@type = 'hidden')",
         '%buttonMatch%' => '%idOrNameMatch% or %valueMatch% or %titleMatch%',
         '%buttonTypeFilter%' => "./@type = 'submit' or ./@type = 'image' or ./@type = 'button' or ./@type = 'reset'",
         '%linkMatch%' => '(%idMatch% or %tagTextMatch% or %titleMatch% or contains(./@rel, %locator%))',
@@ -70,9 +70,6 @@ XPATH
 .//button
 [(%buttonMatch% or %tagTextMatch%)]
 |
-.//input
-[./@type = 'image'][%altMatch%]
-|
 .//*
 [./@role = 'button'][(%buttonMatch% or %tagTextMatch%)]
 XPATH
@@ -89,9 +86,6 @@ XPATH
 |
 .//button
 [(%idOrValueMatch% or %titleMatch% or %tagTextMatch%)]
-|
-.//input
-[./@type = 'image'][%altMatch%]
 |
 .//*
 [(./@role = 'button' or ./@role = 'link')][(%idOrValueMatch% or %titleMatch% or %tagTextMatch%)]

--- a/tests/Behat/Mink/Selector/NamedSelectorTest.php
+++ b/tests/Behat/Mink/Selector/NamedSelectorTest.php
@@ -62,6 +62,8 @@ class NamedSelectorTest extends \PHPUnit_Framework_TestCase
             'field (select, with-id)' => array('test.html', 'field', 'the-field-select', 1),
             'field (input type=submit, with-id) ignored' => array('test.html', 'field', 'the-field-submit-button', 0),
             'field (input type=image, with-id) ignored' => array('test.html', 'field', 'the-field-image-button', 0),
+            'field (input type=button, with-id) ignored' => array('test.html', 'field', 'the-field-button-button', 0),
+            'field (input type=reset, with-id) ignored' => array('test.html', 'field', 'the-field-reset-button', 0),
             'field (input type=hidden, with-id) ignored' => array('test.html', 'field', 'the-field-hidden', 0),
 
             'link (with-href)' => array('test.html', 'link', 'link-text', 5),

--- a/tests/Behat/Mink/Selector/fixtures/test.html
+++ b/tests/Behat/Mink/Selector/fixtures/test.html
@@ -77,26 +77,36 @@
             <!-- don't match fields by `id` attribute -->
             <input type="submit" id="the-field-submit-button"/>
             <input type="image" id="the-field-image-button"/>
+            <input type="button" id="the-field-button-button"/>
+            <input type="reset" id="the-field-reset-button"/>
             <input type="hidden" id="the-field-hidden"/>
 
             <!-- don't match fields by `name` attribute -->
             <input type="submit" name="the-field"/>
             <input type="image" name="the-field"/>
+            <input type="button" name="the-field"/>
+            <input type="reset" name="the-field"/>
             <input type="hidden" name="the-field"/>
 
             <!-- don't match fields by `placeholder` attribute -->
             <input type="submit" placeholder="the-field"/>
             <input type="image" placeholder="the-field"/>
+            <input type="button" placeholder="the-field"/>
+            <input type="reset" placeholder="the-field"/>
             <input type="hidden" placeholder="the-field"/>
 
             <!-- don't match fields by associated label -->
             <label for="label-for-the-field-submit-button">the-field</label><input type="submit" id="label-for-the-field-submit-button"/>
             <label for="label-for-the-field-image-button">the-field</label><input type="image" id="label-for-the-field-image-button"/>
+            <label for="label-for-the-field-button-button">the-field</label><input type="button" id="label-for-the-field-button-button"/>
+            <label for="label-for-the-field-reset-button">the-field</label><input type="reset" id="label-for-the-field-reset-button"/>
             <label for="label-for-the-field-hidden">the-field</label><input type="hidden" id="label-for-the-field-hidden"/>
 
             <!-- don't match fields, surrounded by matching label -->
             <label>the-field<input type="submit"/></label>
             <label>the-field<input type="image"/></label>
+            <label>the-field<input type="button"/></label>
+            <label>the-field<input type="reset"/></label>
             <label>the-field<input type="hidden"/></label>
         </div>
 


### PR DESCRIPTION
1. excluding `input type=button/reset` from `field` selector
2. removing duplicate xpath code from `button` and `link_or_button` selectors

Related to #441 (covered items 1 and 3). 
