### PR TITLE
Ensure all components of a union query are prefixed #340.

### DIFF
--- a/src/Behat/Mink/Element/Element.php
+++ b/src/Behat/Mink/Element/Element.php
@@ -83,9 +83,16 @@ abstract class Element implements ElementInterface
         $currentXpath = $this->getXpath();
         $expressions = array();
 
-        // Split on union operator to ensure we prefix all expressions.
-        // Make sure we ignore operators in brackets.
-        foreach (preg_split('/\|(?![^\[]*\])/', $xpath) as $expression) {
+        // Regex to find union operators not inside brackets.
+        $pattern = '/\|(?![^\[]*\])/';
+
+        // If the parent current xpath contains a union we need to wrap it in parentheses.
+        if (preg_match($pattern, $currentXpath)) {
+            $currentXpath = '(' . $currentXpath . ')';
+        }
+
+        // Split any unions into individual expressions.
+        foreach (preg_split($pattern, $xpath) as $expression) {
             $expression = trim($expression);
             // add parent xpath before element selector
             if (0 === strpos($expression, '/')) {

--- a/tests/Behat/Mink/Element/NodeElementTest.php
+++ b/tests/Behat/Mink/Element/NodeElementTest.php
@@ -319,8 +319,31 @@ class NodeElementTest extends ElementTest
     public function testFindAllUnion()
     {
         $node = new NodeElement('some_xpath', $this->session);
-        $xpath = 'some_tag1 | some_tag2[@foo = "bar|"] | some_tag3[foo | bar]';
-        $expectedPrefixed = 'some_xpath/some_tag1 | some_xpath/some_tag2[@foo = "bar|"] | some_xpath/some_tag3[foo | bar]';
+        $xpath = "some_tag1 | some_tag2[@foo =\n 'bar|'']\n | some_tag3[foo | bar]";
+        $expectedPrefixed = "some_xpath/some_tag1 | some_xpath/some_tag2[@foo =\n 'bar|''] | some_xpath/some_tag3[foo | bar]";
+
+        $this->session->getDriver()
+            ->expects($this->exactly(1))
+            ->method('find')
+            ->will($this->returnValueMap(array(
+                array($expectedPrefixed, array(2, 3, 4)),
+            )));
+
+        $this->selectors
+            ->expects($this->exactly(1))
+            ->method('selectorToXpath')
+            ->will($this->returnValueMap(array(
+                array('xpath', $xpath, $xpath),
+            )));
+
+        $this->assertEquals(3, count($node->findAll('xpath', $xpath)));
+    }
+
+    public function testFindAllParentUnion()
+    {
+        $node = new NodeElement('some_xpath | another_xpath', $this->session);
+        $xpath = "some_tag1 | some_tag2";
+        $expectedPrefixed = "(some_xpath | another_xpath)/some_tag1 | (some_xpath | another_xpath)/some_tag2";
 
         $this->session->getDriver()
             ->expects($this->exactly(1))


### PR DESCRIPTION
Closes #340
