### PR TITLE
Testing various way, how form can be submitted

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -493,6 +493,37 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @dataProvider formSubmitWaysDataProvider
+     */
+    public function testFormSubmitWays($submitVia)
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/basic_form.php'));
+        $page = $session->getPage();
+
+        $firstname = $page->findField('first_name');
+        $firstname->setValue('Konstantin');
+
+        $page->findButton($submitVia)->click();
+
+        if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
+            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+        } else {
+            $this->fail('Form was never submitted');
+        }
+    }
+
+    public function formSubmitWaysDataProvider()
+    {
+        return array(
+            array('Save'),
+            array('input-type-image'),
+            array('button-without-type'),
+            array('button-type-submit'),
+        );
+    }
+
     public function testFormSubmit()
     {
         $session = $this->getSession();

--- a/tests/Behat/Mink/Driver/web-fixtures/basic_form.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/basic_form.php
@@ -12,7 +12,11 @@
         <input id="lastn" name="last_name" value="Lastname" type="text" />
 
         <input type="reset" id="Reset" />
+
         <input type="submit" id="Save" />
+        <input type="image" id="input-type-image"/>
+        <button>button-without-type</button>
+        <button type="submit">button-type-submit</button>
     </form>
 </body>
 </html>


### PR DESCRIPTION
Adding tests to verify, that `<input type="image" .../>`, `<button>...</button>` and `<button type="submit">...</button>` buttons can submit a form.

This is needed to verify MinkBrowserKitDriver behavior added in Behat/MinkBrowserKitDriver#42

Related to: Behat/MinkBrowserKitDriver#29
