### PR TITLE
Tests to verify that html-encoded values are handled properly

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -876,6 +876,24 @@ OUT;
         );
     }
 
+    public function testHtmlDecodingNotPerformed()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/html_decoding.html'));
+        $page = $session->getPage();
+
+        $span = $page->find('css', 'span');
+        $input = $page->find('css', 'input');
+
+        $expectedHtml = '<span custom-attr="&amp;">some text</span>';
+        $this->assertContains($expectedHtml, $page->getHtml(), '.innerHTML is returned as-is');
+        $this->assertContains($expectedHtml, $page->getContent(), '.outerHTML is returned as-is');
+
+        $this->assertEquals('&', $span->getAttribute('custom-attr'), '.getAttribute value is decoded');
+        $this->assertEquals('&', $input->getAttribute('value'), '.getAttribute value is decoded');
+        $this->assertEquals('&', $input->getValue(), 'node value is decoded');
+    }
+
     protected function pathTo($path)
     {
         return $_SERVER['WEB_FIXTURES_HOST'].$path;

--- a/tests/Behat/Mink/Driver/web-fixtures/html_decoding.html
+++ b/tests/Behat/Mink/Driver/web-fixtures/html_decoding.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>HTML Decoding Test</title>
+</head>
+<body>
+    <div>
+        <span custom-attr="&amp;">some text</span>
+
+        <form method="post" action="index.php">
+            <input value="&amp;"/>
+
+            <input type="submit" value="Send"/>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Added test verifies that:
- driver is returning HTML without decoding
- getting attribute value through JavaScript will perform automatic HTML decoding

Uncovers problem reported in Behat/MinkZombieDriver#9
