### PR TITLE
Moved the tests about status code and headers to GeneralDriverTest

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -894,6 +894,36 @@ OUT;
         $this->assertEquals('&', $input->getValue(), 'node value is decoded');
     }
 
+    public function testStatuses()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        try {
+            $this->assertEquals(200, $this->getSession()->getStatusCode());
+        } catch (UnsupportedDriverActionException $e) {
+            $this->markTestSkipped('This driver does not support checking the status code');
+        }
+        $this->assertEquals($this->pathTo('/index.php'), $this->getSession()->getCurrentUrl());
+
+        $this->getSession()->visit($this->pathTo('/404.php'));
+
+        $this->assertEquals($this->pathTo('/404.php'), $this->getSession()->getCurrentUrl());
+        $this->assertEquals(404, $this->getSession()->getStatusCode());
+        $this->assertEquals('Sorry, page not found', $this->getSession()->getPage()->getContent());
+    }
+
+    public function testHeaders()
+    {
+        try {
+            $this->getSession()->setRequestHeader('Accept-Language', 'fr');
+        } catch (UnsupportedDriverActionException $e) {
+            $this->markTestSkipped('This driver does not support setting request header');
+        }
+        $this->getSession()->visit($this->pathTo('/headers.php'));
+
+        $this->assertContains('[HTTP_ACCEPT_LANGUAGE] => fr', $this->getSession()->getPage()->getContent());
+    }
+
     protected function pathTo($path)
     {
         return $_SERVER['WEB_FIXTURES_HOST'].$path;

--- a/tests/Behat/Mink/Driver/HeadlessDriverTest.php
+++ b/tests/Behat/Mink/Driver/HeadlessDriverTest.php
@@ -4,27 +4,9 @@ namespace Tests\Behat\Mink\Driver;
 
 require_once 'GeneralDriverTest.php';
 
+/**
+ * @deprecated Extend GeneralDriverTest directly instead
+ */
 abstract class HeadlessDriverTest extends GeneralDriverTest
 {
-    public function testStatuses()
-    {
-        $this->getSession()->visit($this->pathTo('/index.php'));
-
-        $this->assertEquals(200, $this->getSession()->getStatusCode());
-        $this->assertEquals($this->pathTo('/index.php'), $this->getSession()->getCurrentUrl());
-
-        $this->getSession()->visit($this->pathTo('/404.php'));
-
-        $this->assertEquals($this->pathTo('/404.php'), $this->getSession()->getCurrentUrl());
-        $this->assertEquals(404, $this->getSession()->getStatusCode());
-        $this->assertEquals('Sorry, page not found', $this->getSession()->getPage()->getContent());
-    }
-
-    public function testHeaders()
-    {
-        $this->getSession()->setRequestHeader('Accept-Language', 'fr');
-        $this->getSession()->visit($this->pathTo('/headers.php'));
-
-        $this->assertContains('[HTTP_ACCEPT_LANGUAGE] => fr', $this->getSession()->getPage()->getContent());
-    }
 }


### PR DESCRIPTION
Forcing a distinction between headless drivers and drivers supporting javascript is a bad idea: ZombieDriver is in both categories, so its support of status codes and request headers was untested.
