### PR TITLE
Manipulate only visible fields

### DIFF
--- a/src/Behat/Mink/Element/Element.php
+++ b/src/Behat/Mink/Element/Element.php
@@ -70,6 +70,25 @@ abstract class Element implements ElementInterface
     }
 
     /**
+     * Finds first visible element with specified selector.
+     *
+     * @param string       $selector selector engine name
+     * @param string|array $locator  selector locator
+     *
+     * @return NodeElement|null
+     */
+    public function findFirstVisible($selector, $locator)
+    {
+        $items = $this->findAll($selector, $locator);
+
+        foreach ($items as $item) {
+            if ($item->isVisible()) {
+                return $item;
+            }
+        }
+    }
+
+    /**
      * Finds all elements with specified selector.
      *
      * @param string       $selector selector engine name

--- a/src/Behat/Mink/Element/TraversableElement.php
+++ b/src/Behat/Mink/Element/TraversableElement.php
@@ -148,6 +148,20 @@ abstract class TraversableElement extends Element
     }
 
     /**
+     * Finds first visible field (input, textarea, select) with specified locator.
+     *
+     * @param string $locator input id, name or label
+     *
+     * @return NodeElement|null
+     */
+    public function findFirstVisisbleField($locator)
+    {
+        return $this->findFirstVisible('named', array(
+            'field', $this->getSession()->getSelectorsHandler()->xpathLiteral($locator)
+        ));
+    }
+
+    /**
      * Fills in field (input, textarea, select) with specified locator.
      *
      * @param string $locator input id, name or label
@@ -157,8 +171,7 @@ abstract class TraversableElement extends Element
      */
     public function fillField($locator, $value)
     {
-        $field = $this->findField($locator);
-
+        $field = $this->findFirstVisisbleField($locator);
         if (null === $field) {
             throw new ElementNotFoundException($this->getSession(), 'form field', 'id|name|label|value', $locator);
         }
@@ -203,7 +216,7 @@ abstract class TraversableElement extends Element
      */
     public function checkField($locator)
     {
-        $field = $this->findField($locator);
+        $field = $this->findFirstVisisbleField($locator);
 
         if (null === $field) {
             throw new ElementNotFoundException($this->getSession(), 'form field', 'id|name|label|value', $locator);
@@ -221,7 +234,7 @@ abstract class TraversableElement extends Element
      */
     public function uncheckField($locator)
     {
-        $field = $this->findField($locator);
+        $field = $this->findFirstVisisbleField($locator);
 
         if (null === $field) {
             throw new ElementNotFoundException($this->getSession(), 'form field', 'id|name|label|value', $locator);
@@ -255,7 +268,7 @@ abstract class TraversableElement extends Element
      */
     public function selectFieldOption($locator, $value, $multiple = false)
     {
-        $field = $this->findField($locator);
+        $field = $this->findFirstVisisbleField($locator);
 
         if (null === $field) {
             throw new ElementNotFoundException($this->getSession(), 'form field', 'id|name|label|value', $locator);
@@ -288,7 +301,7 @@ abstract class TraversableElement extends Element
      */
     public function attachFileToField($locator, $path)
     {
-        $field = $this->findField($locator);
+        $field = $this->findFirstVisisbleField($locator);
 
         if (null === $field) {
             throw new ElementNotFoundException($this->getSession(), 'form field', 'id|name|label|value', $locator);


### PR DESCRIPTION
Manipulating hidden fields causes "Element is not currently visible and so may not be interacted with" exception. In addition to find() method looking for labels containing text it causes unability to fill a field if another hidden field contains this text.
Here is an example http://data.gov.uk/user/register
I can't fill "Username" and "Password" fields because Mink is trying to fill fields on the first "I have an account" tab.
Hidden "Username or e-mail address" field on the first tab blocks filling "Username" field on the second tab, the same with hidden "Password"  on the first tab blocking filling "Password" on the second tab.
