### PR TITLE
The "testWaitReturnValue" don't check visibility

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -99,7 +99,7 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
 
-        $found = $this->getSession()->wait(5000, '$("#draggable:visible").length == 1');
+        $found = $this->getSession()->wait(5000, '$("#draggable").length == 1');
         $this->assertTrue($found);
     }
 


### PR DESCRIPTION
Fact, that `testWaitReturnValue` test was looking for `visible element` to make an assertion made all Headless JavaScript-aware drivers very unhappy. This resulted in failed test for them.

Fixes Behat/MinkZombieDriver#64
