### PR TITLE
Mouse tests fix

### DIFF
--- a/tests/Behat/Mink/Driver/JavascriptDriverTest.php
+++ b/tests/Behat/Mink/Driver/JavascriptDriverTest.php
@@ -103,12 +103,13 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $this->assertTrue($found);
     }
 
+    /**
+     * @group mouse-events
+     */
     public function testClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
-
         $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->click();
@@ -116,12 +117,13 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $this->assertEquals('single clicked', $clicker->getText());
     }
 
+    /**
+     * @group mouse-events
+     */
     public function testDoubleClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
-
         $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->doubleClick();
@@ -129,12 +131,13 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $this->assertEquals('double clicked', $clicker->getText());
     }
 
+    /**
+     * @group mouse-events
+     */
     public function testRightClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
-
         $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->rightClick();
@@ -142,43 +145,47 @@ abstract class JavascriptDriverTest extends GeneralDriverTest
         $this->assertEquals('right clicked', $clicker->getText());
     }
 
+    /**
+     * @group mouse-events
+     */
     public function testFocus()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
+        $focusBlurDetector = $this->getSession()->getPage()->find('css', '.elements input#focus-blur-detector');
+        $this->assertEquals('no action detected', $focusBlurDetector->getValue());
 
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
-        $this->assertEquals('not clicked', $clicker->getText());
-
-        $clicker->focus();
+        $focusBlurDetector->focus();
         $this->waitBeforeCheckingMouseEvent('focus');
-        $this->assertEquals('focused', $clicker->getText());
+        $this->assertEquals('focused', $focusBlurDetector->getValue());
     }
 
+    /**
+     * @group mouse-events
+     * @depends testFocus
+     */
     public function testBlur()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
+        $focusBlurDetector = $this->getSession()->getPage()->find('css', '.elements input#focus-blur-detector');
+        $this->assertEquals('no action detected', $focusBlurDetector->getValue());
 
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
-        $this->assertEquals('not clicked', $clicker->getText());
-
-        $clicker->blur();
+        $focusBlurDetector->blur();
         $this->waitBeforeCheckingMouseEvent('blur');
-        $this->assertEquals('blured', $clicker->getText());
+        $this->assertEquals('blured', $focusBlurDetector->getValue());
     }
 
+    /**
+     * @group mouse-events
+     */
     public function testMouseOver()
     {
         $this->getSession()->visit($this->pathTo('/js_test.php'));
+        $mouseOverDetector = $this->getSession()->getPage()->find('css', '.elements div#mouseover-detector');
+        $this->assertEquals('no mouse action detected', $mouseOverDetector->getText());
 
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-
-        $this->assertEquals('not clicked', $clicker->getText());
-
-        $clicker->mouseOver();
+        $mouseOverDetector->mouseOver();
         $this->waitBeforeCheckingMouseEvent('mouseOver');
-        $this->assertEquals('mouse overed', $clicker->getText());
+        $this->assertEquals('mouse overed', $mouseOverDetector->getText());
     }
 
     /**

--- a/tests/Behat/Mink/Driver/web-fixtures/js_test.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/js_test.php
@@ -23,7 +23,9 @@
 <body>
     <div class="elements">
         <div id="clicker">not clicked</div>
+        <div id="mouseover-detector">no mouse action detected</div>
         <div id="invisible" style="display: none">invisible man</div>
+        <input id="focus-blur-detector" type="text" value="no action detected"/>
         <input class="input first" type="text" value="" />
         <input class="input second" type="text" value="" />
         <input class="input third" type="text" value="" />
@@ -54,15 +56,15 @@
                 $(this).text('right clicked');
             });
 
-            $('#clicker').focus(function() {
-                $(this).text('focused');
+            $('#focus-blur-detector').focus(function() {
+                $(this).val('focused');
             });
 
-            $('#clicker').blur(function() {
-                $(this).text('blured');
+            $('#focus-blur-detector').blur(function() {
+                $(this).val('blured');
             });
 
-            $('#clicker').mouseover(function() {
+            $('#mouseover-detector').mouseover(function() {
                 $(this).text('mouse overed');
             });
 


### PR DESCRIPTION
Moving out `mouseover` event checking to separate event for it not to interfere with other mouse event tests. Also I've changed HTML to test focus/blur events on `input` element and not the `div` element, where they can't happen in real life.

Fixes Behat/MinkSelenium2Driver#116
