### PR TITLE
Added a test to ensure consistent behavior accross drivers for 500

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -996,6 +996,13 @@ OUT;
         $this->assertEquals('Sorry, page not found', $this->getSession()->getPage()->getContent());
     }
 
+    public function testVisitErrorPage()
+    {
+        $this->getSession()->visit($this->pathTo('/500.php'));
+
+        $this->assertContains('Sorry, a server error happened', $this->getSession()->getPage()->getContent(), 'Drivers allow loading pages with a 500 status code');
+    }
+
     public function testHeaders()
     {
         $this->getSession()->setRequestHeader('Accept-Language', 'fr');

--- a/tests/Behat/Mink/Driver/web-fixtures/500.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/500.php
@@ -1,0 +1,2 @@
+<?php header("HTTP/1.0 500 Server Error") ?>
+Sorry, a server error happened


### PR DESCRIPTION
This ensures that drivers don't throw an exception if the page is a 500.
An exception in visit() is allowed if the HTTP request cannot be performed, but not if the tested app returns a valid error response.

Refs https://github.com/Behat/Mink/issues/494
I don't know how to write a test to show that an exception is thrown if the request itself cannot be performed. This will depend on the driver, and simulating network failure is hard
