### PR TITLE
Added tests for invalid usages of the drivers

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -1069,6 +1069,245 @@ OUT;
         imagedestroy($img);
     }
 
+    public function testCheckInvalidElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+        $element = $this->getSession()->getPage()->findById('user-name');
+
+        $this->assertNotNull($element);
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->check($element->getXpath());
+    }
+
+    public function testCheckNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->check('//html/.//invalid');
+    }
+
+    public function testUncheckInvalidElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+        $element = $this->getSession()->getPage()->findById('user-name');
+
+        $this->assertNotNull($element);
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->uncheck($element->getXpath());
+    }
+
+    public function testUncheckNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->uncheck('//html/.//invalid');
+    }
+
+    public function testSelectOptionInvalidElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+        $element = $this->getSession()->getPage()->findById('user-name');
+
+        $this->assertNotNull($element);
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->selectOption($element->getXpath(), 'test');
+    }
+
+    public function testSelectOptionNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->selectOption('//html/.//invalid', 'test');
+    }
+
+    public function testAttachFileInvalidElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+        $element = $this->getSession()->getPage()->findById('user-name');
+
+        $this->assertNotNull($element);
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->attachFile($element->getXpath(), __FILE__);
+    }
+
+    public function testAttachFileNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->attachFile('//html/.//invalid', __FILE__);
+    }
+
+    public function testSubmitFormInvalidElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+        $element = $this->getSession()->getPage()->findById('core');
+
+        $this->assertNotNull($element);
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->submitForm($element->getXpath());
+    }
+
+    public function testSubmitFormNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->submitForm('//html/.//invalid');
+    }
+
+    public function testGetTagNameNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->getTagName('//html/.//invalid');
+    }
+
+    public function testGetTextNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->getText('//html/.//invalid');
+    }
+
+    public function testGetHtmlNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->getHtml('//html/.//invalid');
+    }
+
+    public function testGetValueNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->getValue('//html/.//invalid');
+    }
+
+    public function testSetValueNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->setValue('//html/.//invalid', 'test');
+    }
+
+    public function testIsSelectedNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->isSelected('//html/.//invalid');
+    }
+
+    public function testIsCheckedNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->isChecked('//html/.//invalid');
+    }
+
+    public function testIsVisibleNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->isVisible('//html/.//invalid');
+    }
+
+    public function testClickNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->click('//html/.//invalid');
+    }
+
+    public function testDoubleClickNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->doubleClick('//html/.//invalid');
+    }
+
+    public function testRightClickNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->rightClick('//html/.//invalid');
+    }
+
+    public function testGetAttributeNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->getAttribute('//html/.//invalid', 'id');
+    }
+
+    public function testMouseOverFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->mouseOver('//html/.//invalid');
+    }
+
+    public function testFocusFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->focus('//html/.//invalid');
+    }
+
+    public function testBlurFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->blur('//html/.//invalid');
+    }
+
+    public function testKeyPressNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->keyPress('//html/.//invalid', 'a');
+    }
+
+    public function testKeyDownNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->keyDown('//html/.//invalid', 'a');
+    }
+
+    public function testKeyUpNotFoundElement()
+    {
+        $this->getSession()->visit($this->pathTo('/index.php'));
+
+        $this->setExpectedException('Behat\Mink\Exception\DriverException');
+        $this->getSession()->getDriver()->keyUp('//html/.//invalid', 'a');
+    }
+
     protected function pathTo($path)
     {
         return $_SERVER['WEB_FIXTURES_HOST'].$path;

--- a/tests/Behat/Mink/Driver/web-fixtures/index.php
+++ b/tests/Behat/Mink/Driver/web-fixtures/index.php
@@ -44,6 +44,7 @@
                     <input type="text" id="user-name" name="username" />
                 </label>
             </div>
+            <input type="submit" />
         </form>
     </footer>
 </body>


### PR DESCRIPTION
These tests cover calling the driver for XPath not matching elements on the page (case which should not happen in normal usage of Mink given that the driver is accessed from found elements most of the time) or for XPath matching an invalid element (trying to check a div for instance).
These tests ensure that a DriverException is thrown rather than doing an undefined behavior (potentially a fatal error).

Refs https://github.com/Behat/Mink/issues/473 and https://github.com/Behat/Mink/issues/467
