### PR TITLE
Removed the session uniqueId

### DIFF
--- a/src/Behat/Mink/Session.php
+++ b/src/Behat/Mink/Session.php
@@ -24,7 +24,6 @@ class Session
     private $driver;
     private $page;
     private $selectorsHandler;
-    private $uniqueId;
 
     /**
      * Initializes session.
@@ -43,7 +42,6 @@ class Session
         $this->driver           = $driver;
         $this->page             = new DocumentElement($this);
         $this->selectorsHandler = $selectorsHandler;
-        $this->uniqueId         = uniqid('mink_session_');
     }
 
     /**
@@ -97,17 +95,6 @@ class Session
     public function getDriver()
     {
         return $this->driver;
-    }
-
-    /**
-     * Returns session unique id.
-     *
-     * @return string
-     * @access public
-     */
-    public function getUniqueId()
-    {
-        return $this->uniqueId;
     }
 
     /**

--- a/tests/Behat/Mink/SessionTest.php
+++ b/tests/Behat/Mink/SessionTest.php
@@ -273,15 +273,4 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->session->resizeWindow(800, 600, 'test');
     }
-
-    /**
-     * Testing that 2 sessions created with same parameters have different IDs.
-     */
-    public function testUniqueId()
-    {
-        $session  = new Session($this->driver, $this->selectorsHandler);
-
-        $this->assertNotEquals($session->getUniqueId(), $this->session->getUniqueId());
-
-    }
 }


### PR DESCRIPTION
This uniqueId is not used anywhere in Mink, and the value is not even guaranteed to be unique. On windows, uniqid does not have enough entropy to ensure that the testsuite passes consistently for instance.
If the external code needs a way to identify a Session instance uniquely as a scalar, it is better to use spl_object_hash, which will not change as long as the Session is not garbage collected (at which point it is probably the end of the test process).

This is not a BC break requiring to wait until 2.0 as the method has been added after 1.5.0 and so has never been released.

Related to the discussion on https://github.com/Behat/Mink/commit/953c8a88d312b4f1d9da9faca9330a9cff9b35e4#commitcomment-6013152
