### PR TITLE
Improved the description of what resetting a driver means

### DIFF
--- a/src/Behat/Mink/Driver/DriverInterface.php
+++ b/src/Behat/Mink/Driver/DriverInterface.php
@@ -31,6 +31,22 @@ interface DriverInterface
 
     /**
      * Starts driver.
+     *
+     * Once started, the driver should be ready to visit a page.
+     *
+     * Calling any action before visiting a page is an undefined behavior.
+     * The only supported method calls on a fresh driver are
+     * - visit()
+     * - setRequestHeader()
+     * - setBasicAuth()
+     * - reset()
+     * - stop()
+     *
+     * Calling start on a started driver is an undefined behavior. Driver
+     * implementations are free to handle it silently or to fail with an
+     * exception.
+     *
+     * @throws DriverException When the driver cannot be started
      */
     public function start();
 
@@ -43,11 +59,39 @@ interface DriverInterface
 
     /**
      * Stops driver.
+     *
+     * Once stopped, the driver should be started again before using it again.
+     *
+     * Calling any action on a stopped driver is an undefined behavior.
+     * The only supported method call after stopping a driver is starting it again.
+     *
+     * Calling stop on a stopped driver is an undefined behavior. Driver
+     * implementations are free to handle it silently or to fail with an
+     * exception.
+     *
+     * @throws DriverException When the driver cannot be closed
      */
     public function stop();
 
     /**
-     * Resets driver.
+     * Resets driver state.
+     *
+     * This should reset cookies, request headers and basic authentication.
+     * When possible, the history should be reset as well, but this is not enforced
+     * as some implementations may not be able to reset it without restarting the
+     * driver entirely. Consumers requiring a clean history should restart the driver
+     * to enforce it.
+     *
+     * Once reset, the driver should be ready to visit a page.
+     * Calling any action before visiting a page is an undefined behavior.
+     * The only supported method calls on a fresh driver are
+     * - visit()
+     * - setRequestHeader()
+     * - setBasicAuth()
+     * - reset()
+     * - stop()
+     *
+     * Calling reset on a stopped driver is an undefined behavior.
      */
     public function reset();
 

--- a/src/Behat/Mink/Session.php
+++ b/src/Behat/Mink/Session.php
@@ -56,6 +56,14 @@ class Session
 
     /**
      * Starts session driver.
+     *
+     * Calling any action before visiting a page is an undefined behavior.
+     * The only supported method calls on a fresh driver are
+     * - visit()
+     * - setRequestHeader()
+     * - setBasicAuth()
+     * - reset()
+     * - stop()
      */
     public function start()
     {
@@ -80,7 +88,15 @@ class Session
     }
 
     /**
-     * Reset session driver.
+     * Reset session driver state.
+     *
+     * Calling any action before visiting a page is an undefined behavior.
+     * The only supported method calls on a fresh driver are
+     * - visit()
+     * - setRequestHeader()
+     * - setBasicAuth()
+     * - reset()
+     * - stop()
      */
     public function reset()
     {

--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -9,7 +9,6 @@ use Behat\Mink\Session;
 
 abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * Mink session manager.
      *
@@ -180,7 +179,7 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         }
 
         // cookie is removed from all paths
-        $session->reload();
+        $session->visit($this->pathTo('/sub-folder/cookie_page2.php'));
         $this->assertContains('Previous cookie: NO', $session->getPage()->getText());
     }
 
@@ -992,6 +991,23 @@ OUT;
         $this->assertContains('is authenticated', $session->getPage()->getContent());
 
         $session->setBasicAuth(false);
+
+        $session->visit($this->pathTo('/headers.php'));
+
+        $this->assertNotContains('PHP_AUTH_USER', $session->getPage()->getContent());
+    }
+
+    public function testResetWithBasicAuth()
+    {
+        $session = $this->getSession();
+
+        $session->setBasicAuth('mink-user', 'mink-password');
+
+        $session->visit($this->pathTo('/basic_auth.php'));
+
+        $this->assertContains('is authenticated', $session->getPage()->getContent());
+
+        $session->reset();
 
         $session->visit($this->pathTo('/headers.php'));
 


### PR DESCRIPTION
This documents that only a few actions are allowed on a driver which has been started or reset until a page is visited. This matches the behavior of browsers, where you cannot perform actions on a page before opening one.
A new test is added to ensure that the basic auth is properly reset when resetting the driver.

This relates to the discussion in https://github.com/Behat/MinkZombieDriver/pull/86
