### PR TITLE
Added a test for submitting forms without a submit button

### DIFF
--- a/tests/Behat/Mink/Driver/GeneralDriverTest.php
+++ b/tests/Behat/Mink/Driver/GeneralDriverTest.php
@@ -552,6 +552,21 @@ abstract class GeneralDriverTest extends \PHPUnit_Framework_TestCase
         };
     }
 
+    public function testFormSubmitWithoutButton()
+    {
+        $session = $this->getSession();
+        $session->visit($this->pathTo('/form_without_button.html'));
+
+        $page = $session->getPage();
+        $page->findField('first_name')->setValue('Konstantin');
+
+        $page->find('xpath', 'descendant-or-self::form[1]')->submit();
+
+        if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
+            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+        };
+    }
+
     protected function safePageWait($time, $condition)
     {
         try {

--- a/tests/Behat/Mink/Driver/web-fixtures/form_without_button.html
+++ b/tests/Behat/Mink/Driver/web-fixtures/form_without_button.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Form submission without button test</title>
+</head>
+<body>
+    <form action="basic_form_post.php" method="POST">
+        <input name="first_name" type="text" value="not set">
+        <input name="last_name" type="text" value="not set">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
Refs https://github.com/Behat/Mink/issues/497

All drivers except MinkBrowserKitDriver are currently able to use `submitForm` on a form without submit button. And while trying to make a test reaching the exception case in MinkBrowserKitDriver, I discovered that DomCrawler (and even our driver) is able to submit a form without submit button.
The restriction is only in our driver code, which prevents manipulating fields if there is no submit button: we can submit the form, but we cannot change the values. And I managed to remove this restriction from the driver.

So here is a test ensuring this behavior.
