### PR TITLE
Fixed the file upload tests on windows

### DIFF
--- a/driver-testsuite/tests/TestCase.php
+++ b/driver-testsuite/tests/TestCase.php
@@ -93,6 +93,12 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function mapRemoteFilePath($file)
     {
+        $realPath = realpath($file);
+
+        if (false !== $realPath) {
+            $file = $realPath;
+        }
+
         return self::getConfig()->mapRemoteFilePath($file);
     }
 


### PR DESCRIPTION
Some drivers (at least Selenium2) are expecting the path to the file to use the right directory separator, unlike PHP which accepts / on all platforms.
Applying realpath on the path will normalize this on Windows.

This allows the driver tests to pass on Windows.
