### PR TITLE
Fixed the CSS hover test for the right-click event

### DIFF
--- a/driver-testsuite/tests/Css/HoverTest.php
+++ b/driver-testsuite/tests/Css/HoverTest.php
@@ -69,15 +69,6 @@ class HoverTest extends TestCase
         $this->assertActionSquareHeight(200);
     }
 
-    public function tearDown()
-    {
-        if ('testRightClickHover' === $this->getName(false)) {
-            $this->getSession()->getPage()->findById('action-square')->click();
-        }
-
-        parent::tearDown();
-    }
-
     private function assertActionSquareHeight($expected)
     {
         $this->assertEquals(

--- a/driver-testsuite/web-fixtures/css_mouse_events.html
+++ b/driver-testsuite/web-fixtures/css_mouse_events.html
@@ -25,5 +25,12 @@
             <div id="reset-square">reset</div>
             <div id="action-square">mouse action</div>
         </div>
+        <script>
+            $('#action-square').bind('contextmenu', function (e) {
+                // Prevent opening the context menu on right click as the browser might consider the
+                // mouse is in the context menu rather than hovering the element
+                e.preventDefault();
+            });
+        </script>
     </body>
 </html>


### PR DESCRIPTION
When using a real right-click, browsers will open the context menu and the mouse will be over the menu rather than over the element. This prevents the hover styles from being applied.

Refs https://github.com/Behat/MinkSelenium2Driver/pull/148#issuecomment-42768883
