### PR TITLE
Renamed the method of the XPath Escaper class to escapeLiteral

### DIFF
--- a/src/Behat/Mink/Selector/SelectorsHandler.php
+++ b/src/Behat/Mink/Selector/SelectorsHandler.php
@@ -120,6 +120,6 @@ class SelectorsHandler
      */
     public function xpathLiteral($s)
     {
-        return $this->escaper->xpathLiteral($s);
+        return $this->escaper->escapeLiteral($s);
     }
 }

--- a/src/Behat/Mink/Selector/Xpath/Escaper.php
+++ b/src/Behat/Mink/Selector/Xpath/Escaper.php
@@ -11,20 +11,20 @@
 namespace Behat\Mink\Selector\Xpath;
 
 /**
- * Selectors handler.
+ * XPath escaper.
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
 class Escaper
 {
     /**
-     * Translates string to XPath literal.
+     * Escapes the string as a XPath literal.
      *
      * @param string $s
      *
      * @return string
      */
-    public function xpathLiteral($s)
+    public function escapeLiteral($s)
     {
         if (false === strpos($s, "'")) {
             return sprintf("'%s'", $s);

--- a/src/Behat/Mink/Selector/Xpath/Manipulator.php
+++ b/src/Behat/Mink/Selector/Xpath/Manipulator.php
@@ -10,6 +10,12 @@
 
 namespace Behat\Mink\Selector\Xpath;
 
+/**
+ * XPath manipulation utility.
+ *
+ * @author Graham Bates
+ * @author Christophe Coevoet <stof@notk.org>
+ */
 class Manipulator
 {
     /**

--- a/tests/Selector/Xpath/EscaperTest.php
+++ b/tests/Selector/Xpath/EscaperTest.php
@@ -13,7 +13,7 @@ class EscaperTest extends \PHPUnit_Framework_TestCase
     {
         $escaper = new Escaper();
 
-        $this->assertEquals($expected, $escaper->xpathLiteral($string));
+        $this->assertEquals($expected, $escaper->escapeLiteral($string));
     }
 
     public function getXpathLiterals()


### PR DESCRIPTION
When using the class, I think this name makes more sense. I want to do the renaming before merging https://github.com/Behat/MinkSelenium2Driver/pull/151 to avoid being concerned by BC on this class yet.
