### PR TITLE
Moved the Form tests to a dedicated namespace in the testsuite

### DIFF
--- a/driver-testsuite/tests/Form/GeneralTest.php
+++ b/driver-testsuite/tests/Form/GeneralTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Behat\Mink\Tests\Driver\Basic;
+namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
-class FormTest extends TestCase
+class GeneralTest extends TestCase
 {
     /**
      * test accentuated option

--- a/driver-testsuite/tests/Form/Html5Test.php
+++ b/driver-testsuite/tests/Form/Html5Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Behat\Mink\Tests\Driver\Basic;
+namespace Behat\Mink\Tests\Driver\Form;
 
 use Behat\Mink\Tests\Driver\TestCase;
 


### PR DESCRIPTION
As I will add more tests related to forms, I'm moving the existing form tests to a Form namespace instead of having them in Basic. this will make it easier to organize the testsuite when adding more coverage for forms (I will do it for radio now, but #527 is also asking for new form tests)

TODOs:
- update BrowserKitDriver and GoutteDriver to include the Form folder in their testsuite (they are not registering the full driver testsuite to avoid marking all JS tests as skipped
- update ZombieDriver skipping of the HTML5 tests for the new namespace.
