### PR TITLE
Added a test covering the selection of radio groups with HTML5 form attr

### DIFF
--- a/driver-testsuite/tests/Form/Html5Test.php
+++ b/driver-testsuite/tests/Form/Html5Test.php
@@ -35,6 +35,30 @@ OUT;
         }
     }
 
+    public function testHtml5FormRadioAttribute()
+    {
+        $this->getSession()->visit($this->pathTo('html5_radio.html'));
+        $page = $this->getSession()->getPage();
+
+        $radio = $page->findById('sex_f');
+        $otherRadio = $page->findById('sex_invalid');
+
+        $this->assertEquals('f', $radio->getValue());
+        $this->assertEquals('invalid', $otherRadio->getValue());
+
+        $radio->selectOption('m');
+
+        $this->assertEquals('m', $radio->getValue());
+        $this->assertEquals('invalid', $otherRadio->getValue());
+
+        $page->pressButton('Submit in form');
+
+        $out = <<<OUT
+  'sex' = 'm',
+OUT;
+        $this->assertContains($out, $page->getContent());
+    }
+
     public function testHtml5FormButtonAttribute()
     {
         $this->getSession()->visit($this->pathTo('/html5_form.html'));

--- a/driver-testsuite/web-fixtures/html5_radio.html
+++ b/driver-testsuite/web-fixtures/html5_radio.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>HTML5 form attribute test</title>
+</head>
+<body>
+    <form action="advanced_form_post.php" method="POST" id="test-form">
+        <input name="sex" type="radio" value="m" id="sex_m">
+        <input name="sex" type="radio" value="invalid" form="another" id="sex_invalid" checked="checked">
+        <input type="submit" value="Submit in form">
+    </form>
+    <input name="sex" type="radio" form="test-form" value="f" id="sex_f" checked="checked">
+    <form id="another" method="post" action="advanced_form_post.php"></form>
+</body>
+</html>


### PR DESCRIPTION
This ensures that the handling of radio groups works even when the radio elements are using the form attribute to be placed outside the form itself.
When writing tests for https://github.com/Behat/Mink/issues/545 in #554 previously, I forgot to cover the case of radio inputs using the `form` attribute. While it makes no difference when implementing selectOption in BrowserKitDriver (because radio groups are already built on their own in DomCrawler), it makes one for other drivers
