### PR TITLE
Fixed the XPath prefixing when the query wraps a union in braces

### DIFF
--- a/src/Behat/Mink/Selector/Xpath/Manipulator.php
+++ b/src/Behat/Mink/Selector/Xpath/Manipulator.php
@@ -46,13 +46,22 @@ class Manipulator
         // Split any unions into individual expressions.
         foreach (preg_split(self::UNION_PATTERN, $xpath) as $expression) {
             $expression = trim($expression);
+            $parenthesis = '';
+
+            // If the union is inside some braces, we need to preserve the opening braces and apply
+            // the prefix only inside it.
+            if (preg_match('/^[\(\s*]+/', $expression, $matches)) {
+                $parenthesis = $matches[0];
+                $expression = substr($expression, strlen($parenthesis));
+            }
+
             // add prefix before element selector
             if (0 === strpos($expression, '/')) {
                 $expression = $prefix . $expression;
             } else {
                 $expression = $prefix . '/' . $expression;
             }
-            $expressions[] = $expression;
+            $expressions[] = $parenthesis . $expression;
         }
 
         return implode(' | ', $expressions);

--- a/tests/Selector/Xpath/ManipulatorTest.php
+++ b/tests/Selector/Xpath/ManipulatorTest.php
@@ -34,6 +34,16 @@ class ManipulatorTest extends \PHPUnit_Framework_TestCase
                 'some_tag1 | some_tag2',
                 'some_xpath/some_tag1 | some_xpath/some_tag2',
             ),
+            'wrapped union' => array(
+                'some_xpath',
+                '(some_tag1 | some_tag2)/some_child',
+                '(some_xpath/some_tag1 | some_xpath/some_tag2)/some_child',
+            ),
+            'multiple wrapped union' => array(
+                'some_xpath',
+                '( ( some_tag1 | some_tag2)/some_child | some_tag3)/leaf',
+                '( ( some_xpath/some_tag1 | some_xpath/some_tag2)/some_child | some_xpath/some_tag3)/leaf',
+            ),
             'parent union' => array(
                 'some_xpath | another_xpath',
                 'some_tag1 | some_tag2',


### PR DESCRIPTION
If the XPath query is using braces around a union, the logic applying the prefix currently generates a broken query.

I discovered the bug while working on https://github.com/symfony/symfony/pull/10935 which also performs a transformation of XPath queries (more complex than applying a prefix) when running it against the BrowserKitDriver testuite, where we have such queries with braces in them (coming from the Manipulator)
