### PR TITLE
Added a test using the HTML5 form types

### DIFF
--- a/driver-testsuite/tests/Form/Html5Test.php
+++ b/driver-testsuite/tests/Form/Html5Test.php
@@ -105,6 +105,32 @@ OUT;
             $this->assertContains($out, $page->getContent());
             $this->assertNotContains('first_name', $page->getContent());
         }
+    }
 
+    public function testHtml5Types()
+    {
+        $this->getSession()->visit($this->pathTo('html5_types.html'));
+        $page = $this->getSession()->getPage();
+
+        $page->fillField('url', 'http://mink.behat.org/');
+        $page->fillField('email', 'mink@example.org');
+        $page->fillField('number', '6');
+        $page->fillField('search', 'mink');
+        $page->fillField('date', '2014-05-19');
+        $page->fillField('color', '#ff00aa');
+
+        $page->pressButton('Submit');
+
+        $out = <<<OUT
+  'color' = '#ff00aa',
+  'date' = '2014-05-19',
+  'email' = 'mink@example.org',
+  'number' = '6',
+  'search' = 'mink',
+  'submit_button' = 'Submit',
+  'url' = 'http://mink.behat.org/',
+OUT;
+
+        $this->assertContains($out, $page->getContent());
     }
 }

--- a/driver-testsuite/web-fixtures/html5_types.html
+++ b/driver-testsuite/web-fixtures/html5_types.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>HTML5 form attribute test</title>
+</head>
+<body>
+    <form action="advanced_form_post.php" method="POST">
+        <input name="url" type="url">
+        <input name="email" type="email">
+        <input name="number" type="number">
+        <input name="search" type="search">
+        <input name="color" type="color">
+        <input name="date" type="date">
+        <input type="submit" name="submit_button" value="Submit">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
Closes #527

I decided to put them all in a single test for performance reasons (doing a single page load and single form submission rather than 6), as we have the 6 forms on the page anyway (I don't want to have 6 feature files either)

Note: the test is failing on Selenium2Driver locally for me, for color and number types. However, a search on google told me that this is related to the fact that these types have been implemented in Firefox 29 (instead of falling back to normal text fields), and Selenium 2.41 (current stable) officially supports Firefox 28 (as Firefox 29 was not yet released as stable at this time), and so does not know how to handle the new inputs.
This is out of our control. If some people experience a failure there, they should downgrade their firefox to a version supported by Selenium, or wait for the next selenium release.
I think Travis comes with an older version of Firefox (not sure though as their doc still says it is firefox 19 and I clearly doubt about it) so tests could be passing there. And otherwise, we would still be able to force the Firefox version on Travis (with an impact on the build time as it will need to download a firefox binary)
