### PR TITLE
Replaced most null safeguards in tests with usages of WebAssert

### DIFF
--- a/driver-testsuite/tests/Basic/ContentTest.php
+++ b/driver-testsuite/tests/Basic/ContentTest.php
@@ -10,10 +10,7 @@ class ContentTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/index.html'));
 
-        $page = $this->getSession()->getPage();
-        $element = $page->find('css', '.travers');
-
-        $this->assertNotNull($element);
+        $element = $this->getAssertSession()->elementExists('css', '.travers');
 
         $this->assertEquals(
             "<div class=\"travers\">\n            <div class=\"sub\">el1</div>\n".
@@ -59,14 +56,12 @@ class ContentTest extends TestCase
     public function testHtmlDecodingNotPerformed()
     {
         $session = $this->getSession();
+        $webAssert = $this->getAssertSession();
         $session->visit($this->pathTo('/html_decoding.html'));
         $page = $session->getPage();
 
-        $span = $page->find('css', 'span');
-        $input = $page->find('css', 'input');
-
-        $this->assertNotNull($span);
-        $this->assertNotNull($input);
+        $span = $webAssert->elementExists('css', 'span');
+        $input = $webAssert->elementExists('css', 'input');
 
         $expectedHtml = '<span custom-attr="&amp;">some text</span>';
         $this->assertContains($expectedHtml, $page->getHtml(), '.innerHTML is returned as-is');

--- a/driver-testsuite/tests/Basic/CookieTest.php
+++ b/driver-testsuite/tests/Basic/CookieTest.php
@@ -148,19 +148,20 @@ class CookieTest extends TestCase
     public function testSessionPersistsBetweenRequests()
     {
         $this->getSession()->visit($this->pathTo('/session_test.php'));
-        $this->assertNotNull($node = $this->getSession()->getPage()->find('css', '#session-id'));
+        $webAssert = $this->getAssertSession();
+        $node = $webAssert->elementExists('css', '#session-id');
         $sessionId = $node->getText();
 
         $this->getSession()->visit($this->pathTo('/session_test.php'));
-        $this->assertNotNull($node = $this->getSession()->getPage()->find('css', '#session-id'));
+        $node = $webAssert->elementExists('css', '#session-id');
         $this->assertEquals($sessionId, $node->getText());
 
         $this->getSession()->visit($this->pathTo('/session_test.php?login'));
-        $this->assertNotNull($node = $this->getSession()->getPage()->find('css', '#session-id'));
+        $node = $webAssert->elementExists('css', '#session-id');
         $this->assertNotEquals($sessionId, $newSessionId = $node->getText());
 
         $this->getSession()->visit($this->pathTo('/session_test.php'));
-        $this->assertNotNull($node = $this->getSession()->getPage()->find('css', '#session-id'));
+        $node = $webAssert->elementExists('css', '#session-id');
         $this->assertEquals($newSessionId, $node->getText());
     }
 }

--- a/driver-testsuite/tests/Basic/IFrameTest.php
+++ b/driver-testsuite/tests/Basic/IFrameTest.php
@@ -9,22 +9,19 @@ class IFrameTest extends TestCase
     public function testIFrame()
     {
         $this->getSession()->visit($this->pathTo('/iframe.html'));
-        $page = $this->getSession()->getPage();
+        $webAssert = $this->getAssertSession();
 
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
 
         $this->getSession()->switchToIFrame('subframe');
 
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('iFrame div text', $el->getText());
 
         $this->getSession()->switchToIFrame();
 
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
     }
 }

--- a/driver-testsuite/tests/Basic/VisibilityTest.php
+++ b/driver-testsuite/tests/Basic/VisibilityTest.php
@@ -9,12 +9,10 @@ class VisibilityTest extends TestCase
     public function testVisibility()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
+        $webAssert = $this->getAssertSession();
 
-        $clicker   = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-        $invisible = $this->getSession()->getPage()->find('css', '#invisible');
-
-        $this->assertNotNull($clicker);
-        $this->assertNotNull($invisible);
+        $clicker   = $webAssert->elementExists('css', '.elements div#clicker');
+        $invisible = $webAssert->elementExists('css', '#invisible');
 
         $this->assertFalse($invisible->isVisible());
         $this->assertTrue($clicker->isVisible());

--- a/driver-testsuite/tests/Form/CheckboxTest.php
+++ b/driver-testsuite/tests/Form/CheckboxTest.php
@@ -49,15 +49,12 @@ class CheckboxTest extends TestCase
     public function testCheckboxMultiple()
     {
         $this->getSession()->visit($this->pathTo('/multicheckbox_form.html'));
+        $webAssert = $this->getAssertSession();
 
-        $page = $this->getSession()->getPage();
-        $this->assertEquals('Multicheckbox Test', $page->find('css', 'h1')->getText());
+        $this->assertEquals('Multicheckbox Test', $webAssert->elementExists('css', 'h1')->getText());
 
-        $updateMail  = $page->find('css', '[name="mail_types[]"][value="update"]');
-        $spamMail    = $page->find('css', '[name="mail_types[]"][value="spam"]');
-
-        $this->assertNotNull($updateMail);
-        $this->assertNotNull($spamMail);
+        $updateMail  = $webAssert->elementExists('css', '[name="mail_types[]"][value="update"]');
+        $spamMail    = $webAssert->elementExists('css', '[name="mail_types[]"][value="spam"]');
 
         $this->assertTrue($updateMail->getValue());
         $this->assertFalse($spamMail->getValue());

--- a/driver-testsuite/tests/Form/GeneralTest.php
+++ b/driver-testsuite/tests/Form/GeneralTest.php
@@ -23,14 +23,12 @@ class GeneralTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/basic_form.html'));
 
+        $webAssert = $this->getAssertSession();
         $page = $this->getSession()->getPage();
-        $this->assertEquals('Basic Form Page', $page->find('css', 'h1')->getText());
+        $this->assertEquals('Basic Form Page', $webAssert->elementExists('css', 'h1')->getText());
 
-        $firstname  = $page->findField('first_name');
-        $lastname   = $page->findField('lastn');
-
-        $this->assertNotNull($firstname);
-        $this->assertNotNull($lastname);
+        $firstname  = $webAssert->fieldExists('first_name');
+        $lastname   = $webAssert->fieldExists('lastn');
 
         $this->assertEquals('Firstname', $firstname->getValue());
         $this->assertEquals('Lastname', $lastname->getValue());
@@ -52,9 +50,9 @@ class GeneralTest extends TestCase
         $page->findButton('Save')->click();
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
-            $this->assertEquals('Anket for Konstantin', $page->find('css', 'h1')->getText());
-            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
-            $this->assertEquals('Lastname: Kudryashov', $page->find('css', '#last')->getText());
+            $this->assertEquals('Anket for Konstantin', $webAssert->elementExists('css', 'h1')->getText());
+            $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
+            $this->assertEquals('Lastname: Kudryashov', $webAssert->elementExists('css', '#last')->getText());
         }
     }
 
@@ -66,15 +64,15 @@ class GeneralTest extends TestCase
         $session = $this->getSession();
         $session->visit($this->pathTo('/basic_form.html'));
         $page = $session->getPage();
+        $webAssert = $this->getAssertSession();
 
-        $firstname = $page->findField('first_name');
-        $this->assertNotNull($firstname);
+        $firstname = $webAssert->fieldExists('first_name');
         $firstname->setValue('Konstantin');
 
         $page->findButton($submitVia)->click();
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
-            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+            $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
         } else {
             $this->fail('Form was never submitted');
         }
@@ -95,13 +93,13 @@ class GeneralTest extends TestCase
         $session = $this->getSession();
         $session->visit($this->pathTo('/basic_form.html'));
 
-        $page = $session->getPage();
-        $page->findField('first_name')->setValue('Konstantin');
+        $webAssert = $this->getAssertSession();
+        $webAssert->fieldExists('first_name')->setValue('Konstantin');
 
-        $page->find('xpath', 'descendant-or-self::form[1]')->submit();
+        $webAssert->elementExists('xpath', 'descendant-or-self::form[1]')->submit();
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
-            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+            $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
         };
     }
 
@@ -110,29 +108,29 @@ class GeneralTest extends TestCase
         $session = $this->getSession();
         $session->visit($this->pathTo('/form_without_button.html'));
 
-        $page = $session->getPage();
-        $page->findField('first_name')->setValue('Konstantin');
+        $webAssert = $this->getAssertSession();
+        $webAssert->fieldExists('first_name')->setValue('Konstantin');
 
-        $page->find('xpath', 'descendant-or-self::form[1]')->submit();
+        $webAssert->elementExists('xpath', 'descendant-or-self::form[1]')->submit();
 
         if ($this->safePageWait(5000, 'document.getElementById("first") !== null')) {
-            $this->assertEquals('Firstname: Konstantin', $page->find('css', '#first')->getText());
+            $this->assertEquals('Firstname: Konstantin', $webAssert->elementExists('css', '#first')->getText());
         };
     }
 
     public function testBasicGetForm()
     {
         $this->getSession()->visit($this->pathTo('/basic_get_form.php'));
+        $webAssert = $this->getAssertSession();
 
         $page = $this->getSession()->getPage();
-        $this->assertEquals('Basic Get Form Page', $page->find('css', 'h1')->getText());
+        $this->assertEquals('Basic Get Form Page', $webAssert->elementExists('css', 'h1')->getText());
 
-        $search = $page->findField('q');
-        $this->assertNotNull($search);
+        $search = $webAssert->fieldExists('q');
         $search->setValue('some#query');
         $page->pressButton('Find');
 
-        $this->assertNotNull($div = $page->find('css', 'div'));
+        $div = $webAssert->elementExists('css', 'div');
         $this->assertEquals('some#query', $div->getText());
     }
 
@@ -150,27 +148,19 @@ class GeneralTest extends TestCase
 
         $this->getSession()->visit($this->pathTo('/advanced_form.html'));
 
+        $webAssert = $this->getAssertSession();
         $page = $this->getSession()->getPage();
-        $this->assertEquals('ADvanced Form Page', $page->find('css', 'h1')->getText());
+        $this->assertEquals('ADvanced Form Page', $webAssert->elementExists('css', 'h1')->getText());
 
-        $firstname   = $page->findField('first_name');
-        $lastname    = $page->findField('lastn');
-        $email       = $page->findField('Your email:');
-        $select      = $page->findField('select_number');
-        $sex         = $page->findField('sex');
-        $maillist    = $page->findField('mail_list');
-        $agreement   = $page->findField('agreement');
-        $notes       = $page->findField('notes');
-        $about       = $page->findField('about');
-
-        $this->assertNotNull($firstname);
-        $this->assertNotNull($lastname);
-        $this->assertNotNull($email);
-        $this->assertNotNull($select);
-        $this->assertNotNull($sex);
-        $this->assertNotNull($maillist);
-        $this->assertNotNull($agreement);
-        $this->assertNotNull($notes);
+        $firstname   = $webAssert->fieldExists('first_name');
+        $lastname    = $webAssert->fieldExists('lastn');
+        $email       = $webAssert->fieldExists('Your email:');
+        $select      = $webAssert->fieldExists('select_number');
+        $sex         = $webAssert->fieldExists('sex');
+        $maillist    = $webAssert->fieldExists('mail_list');
+        $agreement   = $webAssert->fieldExists('agreement');
+        $notes       = $webAssert->fieldExists('notes');
+        $about       = $webAssert->fieldExists('about');
 
         $this->assertEquals('Firstname', $firstname->getValue());
         $this->assertEquals('Lastname', $lastname->getValue());
@@ -236,15 +226,12 @@ OUT;
     {
         $this->getSession()->visit($this->pathTo('/multi_input_form.html'));
         $page = $this->getSession()->getPage();
-        $this->assertEquals('Multi input Test', $page->find('css', 'h1')->getText());
+        $webAssert = $this->getAssertSession();
+        $this->assertEquals('Multi input Test', $webAssert->elementExists('css', 'h1')->getText());
 
-        $first = $page->findField('First');
-        $second = $page->findField('Second');
-        $third = $page->findField('Third');
-
-        $this->assertNotNull($first);
-        $this->assertNotNull($second);
-        $this->assertNotNull($third);
+        $first = $webAssert->fieldExists('First');
+        $second = $webAssert->fieldExists('Second');
+        $third = $webAssert->fieldExists('Third');
 
         $this->assertEquals('tag1', $first->getValue());
         $this->assertSame('tag2', $second->getValue());

--- a/driver-testsuite/tests/Form/Html5Test.php
+++ b/driver-testsuite/tests/Form/Html5Test.php
@@ -10,12 +10,10 @@ class Html5Test extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/html5_form.html'));
         $page = $this->getSession()->getPage();
+        $webAssert = $this->getAssertSession();
 
-        $firstName = $page->findField('first_name');
-        $lastName = $page->findField('last_name');
-
-        $this->assertNotNull($firstName);
-        $this->assertNotNull($lastName);
+        $firstName = $webAssert->fieldExists('first_name');
+        $lastName = $webAssert->fieldExists('last_name');
 
         $this->assertEquals('not set', $lastName->getValue());
         $firstName->setValue('John');
@@ -63,12 +61,10 @@ OUT;
     {
         $this->getSession()->visit($this->pathTo('/html5_form.html'));
         $page = $this->getSession()->getPage();
+        $webAssert = $this->getAssertSession();
 
-        $firstName = $page->findField('first_name');
-        $lastName = $page->findField('last_name');
-
-        $this->assertNotNull($firstName);
-        $this->assertNotNull($lastName);
+        $firstName = $webAssert->fieldExists('first_name');
+        $lastName = $webAssert->fieldExists('last_name');
 
         $firstName->setValue('John');
         $lastName->setValue('Doe');
@@ -90,11 +86,7 @@ OUT;
         $this->getSession()->visit($this->pathTo('/html5_form.html'));
         $page = $this->getSession()->getPage();
 
-        $field = $page->findField('other_field');
-
-        $this->assertNotNull($field);
-
-        $field->setValue('hello');
+        $page->fillField('other_field', 'hello');
 
         $page->pressButton('Submit separate form');
 

--- a/driver-testsuite/tests/Form/SelectTest.php
+++ b/driver-testsuite/tests/Form/SelectTest.php
@@ -9,16 +9,13 @@ class SelectTest extends TestCase
     public function testMultiselect()
     {
         $this->getSession()->visit($this->pathTo('/multiselect_form.html'));
+        $webAssert = $this->getAssertSession();
         $page = $this->getSession()->getPage();
-        $this->assertEquals('Multiselect Test', $page->find('css', 'h1')->getText());
+        $this->assertEquals('Multiselect Test', $webAssert->elementExists('css', 'h1')->getText());
 
-        $select      = $page->findField('select_number');
-        $multiSelect = $page->findField('select_multiple_numbers[]');
-        $secondMultiSelect = $page->findField('select_multiple_values[]');
-
-        $this->assertNotNull($select);
-        $this->assertNotNull($multiSelect);
-        $this->assertNotNull($secondMultiSelect);
+        $select      = $webAssert->fieldExists('select_number');
+        $multiSelect = $webAssert->fieldExists('select_multiple_numbers[]');
+        $secondMultiSelect = $webAssert->fieldExists('select_multiple_values[]');
 
         $this->assertEquals('20', $select->getValue());
         $this->assertSame(array(), $multiSelect->getValue());
@@ -65,13 +62,12 @@ OUT;
     public function testElementSelectedStateCheck($selectName, $optionValue, $optionText)
     {
         $session = $this->getSession();
+        $webAssert = $this->getAssertSession();
         $session->visit($this->pathTo('/multiselect_form.html'));
-        $select = $session->getPage()->findField($selectName);
-        $this->assertNotNull($select);
+        $select = $webAssert->fieldExists($selectName);
 
         $optionValueEscaped = $session->getSelectorsHandler()->xpathLiteral($optionValue);
-        $option = $select->find('named', array('option', $optionValueEscaped));
-        $this->assertNotNull($option);
+        $option = $webAssert->elementExists('named', array('option', $optionValueEscaped));
 
         $this->assertFalse($option->isSelected());
         $select->selectOption($optionText);
@@ -90,8 +86,7 @@ OUT;
     {
         $session = $this->getSession();
         $session->visit($this->pathTo('/multiselect_form.html'));
-        $select = $session->getPage()->findField('select_number');
-        $this->assertNotNull($select);
+        $select = $this->getAssertSession()->fieldExists('select_number');
 
         $select->setValue('10');
         $this->assertEquals('10', $select->getValue());
@@ -101,8 +96,7 @@ OUT;
     {
         $session = $this->getSession();
         $session->visit($this->pathTo('/multiselect_form.html'));
-        $select = $session->getPage()->findField('select_multiple_values[]');
-        $this->assertNotNull($select);
+        $select = $this->getAssertSession()->fieldExists('select_multiple_values[]');
 
         $select->setValue(array('1', '2'));
         $this->assertEquals(array('1', '2'), $select->getValue());

--- a/driver-testsuite/tests/Js/EventsTest.php
+++ b/driver-testsuite/tests/Js/EventsTest.php
@@ -12,8 +12,7 @@ class EventsTest extends TestCase
     public function testClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-        $this->assertNotNull($clicker);
+        $clicker = $this->getAssertSession()->elementExists('css', '.elements div#clicker');
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->click();
@@ -26,8 +25,7 @@ class EventsTest extends TestCase
     public function testDoubleClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-        $this->assertNotNull($clicker);
+        $clicker = $this->getAssertSession()->elementExists('css', '.elements div#clicker');
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->doubleClick();
@@ -40,8 +38,7 @@ class EventsTest extends TestCase
     public function testRightClick()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $clicker = $this->getSession()->getPage()->find('css', '.elements div#clicker');
-        $this->assertNotNull($clicker);
+        $clicker = $this->getAssertSession()->elementExists('css', '.elements div#clicker');
         $this->assertEquals('not clicked', $clicker->getText());
 
         $clicker->rightClick();
@@ -54,8 +51,7 @@ class EventsTest extends TestCase
     public function testFocus()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $focusBlurDetector = $this->getSession()->getPage()->find('css', '.elements input#focus-blur-detector');
-        $this->assertNotNull($focusBlurDetector);
+        $focusBlurDetector = $this->getAssertSession()->elementExists('css', '.elements input#focus-blur-detector');
         $this->assertEquals('no action detected', $focusBlurDetector->getValue());
 
         $focusBlurDetector->focus();
@@ -69,8 +65,7 @@ class EventsTest extends TestCase
     public function testBlur()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $focusBlurDetector = $this->getSession()->getPage()->find('css', '.elements input#focus-blur-detector');
-        $this->assertNotNull($focusBlurDetector);
+        $focusBlurDetector = $this->getAssertSession()->elementExists('css', '.elements input#focus-blur-detector');
         $this->assertEquals('no action detected', $focusBlurDetector->getValue());
 
         $focusBlurDetector->blur();
@@ -83,8 +78,7 @@ class EventsTest extends TestCase
     public function testMouseOver()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
-        $mouseOverDetector = $this->getSession()->getPage()->find('css', '.elements div#mouseover-detector');
-        $this->assertNotNull($mouseOverDetector);
+        $mouseOverDetector = $this->getAssertSession()->elementExists('css', '.elements div#mouseover-detector');
         $this->assertEquals('no mouse action detected', $mouseOverDetector->getText());
 
         $mouseOverDetector->mouseOver();
@@ -97,16 +91,12 @@ class EventsTest extends TestCase
     public function testKeyboardEvents($modifier, $eventProperties)
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
+        $webAssert = $this->getAssertSession();
 
-        $input1 = $this->getSession()->getPage()->find('css', '.elements input.input.first');
-        $input2 = $this->getSession()->getPage()->find('css', '.elements input.input.second');
-        $input3 = $this->getSession()->getPage()->find('css', '.elements input.input.third');
-        $event  = $this->getSession()->getPage()->find('css', '.elements .text-event');
-
-        $this->assertNotNull($input1);
-        $this->assertNotNull($input2);
-        $this->assertNotNull($input3);
-        $this->assertNotNull($event);
+        $input1 = $webAssert->elementExists('css', '.elements input.input.first');
+        $input2 = $webAssert->elementExists('css', '.elements input.input.second');
+        $input3 = $webAssert->elementExists('css', '.elements input.input.third');
+        $event  = $webAssert->elementExists('css', '.elements .text-event');
 
         $input1->keyDown('u', $modifier);
         $this->assertEquals('key downed:' . $eventProperties, $event->getText());

--- a/driver-testsuite/tests/Js/JavascriptEvaluationTest.php
+++ b/driver-testsuite/tests/Js/JavascriptEvaluationTest.php
@@ -44,8 +44,7 @@ class JavascriptEvaluationTest extends TestCase
 
         sleep(1);
 
-        $heading = $this->getSession()->getPage()->find('css', 'h1');
-        $this->assertNotNull($heading);
+        $heading = $this->getAssertSession()->elementExists('css', 'h1');
         $this->assertEquals('Hello world', $heading->getText());
     }
 

--- a/driver-testsuite/tests/Js/JavascriptTest.php
+++ b/driver-testsuite/tests/Js/JavascriptTest.php
@@ -21,12 +21,10 @@ class JavascriptTest extends TestCase
     public function testDragDrop()
     {
         $this->getSession()->visit($this->pathTo('/js_test.html'));
+        $webAssert = $this->getAssertSession();
 
-        $draggable = $this->getSession()->getPage()->find('css', '#draggable');
-        $droppable = $this->getSession()->getPage()->find('css', '#droppable');
-
-        $this->assertNotNull($draggable);
-        $this->assertNotNull($droppable);
+        $draggable = $webAssert->elementExists('css', '#draggable');
+        $droppable = $webAssert->elementExists('css', '#droppable');
 
         $draggable->dragTo($droppable);
         $this->assertEquals('Dropped!', $droppable->find('css', 'p')->getText());

--- a/driver-testsuite/tests/Js/WindowTest.php
+++ b/driver-testsuite/tests/Js/WindowTest.php
@@ -11,6 +11,7 @@ class WindowTest extends TestCase
         $this->getSession()->visit($this->pathTo('/window.html'));
         $session = $this->getSession();
         $page    = $session->getPage();
+        $webAssert = $this->getAssertSession();
 
         $page->clickLink('Popup #1');
         $session->switchToWindow(null);
@@ -18,23 +19,19 @@ class WindowTest extends TestCase
         $page->clickLink('Popup #2');
         $session->switchToWindow(null);
 
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
 
         $session->switchToWindow('popup_1');
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Popup#1 div text', $el->getText());
 
         $session->switchToWindow('popup_2');
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Popup#2 div text', $el->getText());
 
         $session->switchToWindow(null);
-        $el = $page->find('css', '#text');
-        $this->assertNotNull($el);
+        $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Main window div text', $el->getText());
     }
 


### PR DESCRIPTION
The `assertNotNull` calls are kept in 2 cases:
- in the `TraversingTest` as they are the real assertions of the tests
- in case `findById()` or `findButton()` are used, as these shortcut are more readable than calling elementExists() with a named selector, especially considering the fact that it would require applying the XPath escaping manually in these places.
