### PR TITLE
Added a test forbidding to expand CoreDriver outside the DriverInterface

### DIFF
--- a/tests/Driver/CoreDriverTest.php
+++ b/tests/Driver/CoreDriverTest.php
@@ -4,6 +4,19 @@ namespace Behat\Mink\Tests\Driver;
 
 class CoreDriverTest extends \PHPUnit_Framework_TestCase
 {
+    public function testNoExtraMethods()
+    {
+        $interfaceRef = new \ReflectionClass('Behat\Mink\Driver\DriverInterface');
+        $coreDriverRef = new \ReflectionClass('Behat\Mink\Driver\CoreDriver');
+
+        foreach ($coreDriverRef->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            $this->assertTrue(
+                $interfaceRef->hasMethod($method->getName()),
+                sprintf('CoreDriver should not implement methods which are not part of the DriverInterface but %s found', $method->getName())
+            );
+        }
+    }
+
     /**
      * @dataProvider getDriverInterfaceMethods
      */


### PR DESCRIPTION
The goal is to prevent mistakes in contributions where new features are added in CoreDriver without being added in the interface.

I thought about this when reviewing https://github.com/Behat/Mink/pull/596. What do you think @aik099 ?
