### PR TITLE
Change timeout of "ElementInterface::waitFor" to be in seconds

### DIFF
--- a/src/Behat/Mink/Element/Element.php
+++ b/src/Behat/Mink/Element/Element.php
@@ -117,7 +117,7 @@ abstract class Element implements ElementInterface
         }
 
         $start = microtime(true);
-        $end = $start + $timeout / 1000.0;
+        $end = $start + $timeout;
 
         do {
             $result = call_user_func($callback, $this);

--- a/src/Behat/Mink/Element/ElementInterface.php
+++ b/src/Behat/Mink/Element/ElementInterface.php
@@ -57,9 +57,9 @@ interface ElementInterface
     /**
      * Waits for an element(-s) to appear and returns it.
      *
-     * @param int      $timeout  Maximal allowed waiting time in milliseconds.
-     * @param callable $callback Callback, which result is both used as waiting condition and returned.
-     *                           Will receive reference to `this element` as first argument.
+     * @param int|float $timeout  Maximal allowed waiting time in seconds.
+     * @param callable  $callback Callback, which result is both used as waiting condition and returned.
+     *                            Will receive reference to `this element` as first argument.
      *
      * @return mixed
      * @throws \InvalidArgumentException When invalid callback given.

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -75,7 +75,7 @@ class NodeElementTest extends ElementTest
         $callCounter = 0;
         $node = new NodeElement('some xpath', $this->session);
 
-        $result = $node->waitFor(5000, function ($givenNode) use (&$callCounter) {
+        $result = $node->waitFor(5, function ($givenNode) use (&$callCounter) {
             $callCounter++;
 
             if (1 === $callCounter) {
@@ -99,7 +99,7 @@ class NodeElementTest extends ElementTest
 
         $expectedTimeout = 2;
         $startTime = microtime(true);
-        $result = $node->waitFor($expectedTimeout * 1000, function () {
+        $result = $node->waitFor($expectedTimeout, function () {
             return null;
         });
         $endTime = microtime(true);
@@ -114,7 +114,7 @@ class NodeElementTest extends ElementTest
     public function testWaitForFailure()
     {
         $node = new NodeElement('some xpath', $this->session);
-        $node->waitFor(5000, 'not a callable');
+        $node->waitFor(5, 'not a callable');
     }
 
     public function testHasAttribute()


### PR DESCRIPTION
Having timeout for element waiting in seconds makes more sense, because method is designed to wait for elements to appear from AJAX requests, which usually doesn't take milliseconds to run. In any case having `0.1` as wait timeout seems more readable, then `100`.
