### PR TITLE
Added the SensioLabs Insight badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Mink
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/Behat/Mink/badges/quality-score.png?s=d4faf469d6b399df121deed6070390800722ada0)](https://scrutinizer-ci.com/g/Behat/Mink/)
 [![Code Coverage](https://scrutinizer-ci.com/g/Behat/Mink/badges/coverage.png?s=88ab1cee4e131f4ef595f17ae4837001ef2aec3b)](https://scrutinizer-ci.com/g/Behat/Mink/)
 [![Build Status](https://travis-ci.org/Behat/Mink.svg?branch=master)](https://travis-ci.org/Behat/Mink)
+[![SensioLabsInsight](https://insight.sensiolabs.com/projects/5bb8fab0-978f-428a-ae23-44ee4e129fbc/mini.png)](https://insight.sensiolabs.com/projects/5bb8fab0-978f-428a-ae23-44ee4e129fbc)
 [![License](https://poser.pugx.org/behat/mink/license.svg)](https://packagist.org/packages/behat/mink)
+
 
 Useful Links
 ------------


### PR DESCRIPTION
I configured Insight to run on Mink (I added a webhook for that so that it runs on each push). Given that it gives us a platinum medal, I think it might be worth adding it to the readme.

I'm not sure I will enable it for all driver (some drivers have most of their logic in JS so it provides much less feedback on them, and we already have Scrutinizer detecting issues through static analysis), but this is subject to discussion.
