### PR TITLE
Fixed the search by id in the driver testsuite

### DIFF
--- a/driver-testsuite/tests/TestCase.php
+++ b/driver-testsuite/tests/TestCase.php
@@ -102,6 +102,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected function findById($id)
     {
+        $id = $this->getSession()->getSelectorsHandler()->xpathLiteral($id);
+
         return $this->getAssertSession()->elementExists('named', array('id', $id));
     }
 


### PR DESCRIPTION
Mink 1.x requires escaping the locator before passing it to the named selector, and I forgot it in #610.
