### PR TITLE
Added an extra test to ensure the right behavior for traversal

### DIFF
--- a/driver-testsuite/tests/Basic/TraversingTest.php
+++ b/driver-testsuite/tests/Basic/TraversingTest.php
@@ -126,4 +126,14 @@ class TraversingTest extends TestCase
         $this->assertFalse($subUrl->has('css', 'em'));
         $this->assertEquals('deep', $subUrl->find('css', 'strong')->getText());
     }
+
+    public function testFindingChild()
+    {
+        $this->getSession()->visit($this->pathTo('/index.html'));
+
+        $form = $this->getSession()->getPage()->find('css', 'footer form');
+        $this->assertNotNull($form);
+
+        $this->assertCount(1, $form->findAll('css', 'input'), 'Elements are searched only in the element, not in all previous matches');
+    }
 }


### PR DESCRIPTION
Technically, using the provided XPath in a driver for the first matched element rather than using a restriction of this element to the first match will give you the same element match for `find()` (as it will get the first match only). But it can break searching for children elements (it would search them in all matches for `footer form` rather than only the first match).
By curiosity, I broke BrowserKitDriver to do exactly this and ran the testsuite. And it was passing, which is bad. So here is the missing test to ensure that `$element->findAll()` searches only in the right element, and not in all previous matches.
