### PR TITLE
Solve HTML file reading issue on HHVM 3.0

### DIFF
--- a/tests/Selector/NamedSelectorTest.php
+++ b/tests/Selector/NamedSelectorTest.php
@@ -38,8 +38,9 @@ abstract class NamedSelectorTest extends \PHPUnit_Framework_TestCase
             ? $expectedPartialCount
             : $expectedExactCount;
 
+        // Don't use "loadHTMLFile" due HHVM 3.3.0 issue.
         $dom = new \DOMDocument('1.0', 'UTF-8');
-        $dom->loadHTMLFile(__DIR__.'/fixtures/'.$fixtureFile);
+        $dom->loadHTML(file_get_contents(__DIR__.'/fixtures/'.$fixtureFile));
 
         // Escape the locator as Mink 1.x expects the caller of the NamedSelector to handle it
         $selectorsHandler = new SelectorsHandler();


### PR DESCRIPTION
On HHVM 3.0 attempt to use `loadHTMLFile` method on `DOMDocument` class instance results in following error (see https://travis-ci.org/Behat/Mink/jobs/36653510 build):

```
Behat\Mink\Tests\Selector\PartialNamedSelectorTest::testSelectors with data set "link (without-href) ignored" ('test.html', 'link', 'bad-link-text', 0)
Protocol 'file' for external XML entity '/home/travis/build/Behat/Mink/tests/Selector/fixtures/test.html' is disabled for security reasons. This may be changed using the hhvm.libxml.ext_entity_whitelist ini setting.
```

However adding to proposed setting to `/etc/hhvm/php.ini` on Travis CI to allow "file" protocol has no effect.

To overcome this for HHVM only I load file separately and then just given HTML to the problematic method.
