### PR TITLE
Add empty check for path in WebAssert cleanUrl()

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -648,8 +648,9 @@ class WebAssert
     {
         $parts = parse_url($url);
         $fragment = empty($parts['fragment']) ? '' : '#' . $parts['fragment'];
+        $path = empty($parts['path']) ? '/' : $parts['path'];
 
-        return preg_replace('/^\/[^\.\/]+\.php/', '', $parts['path']) . $fragment;
+        return preg_replace('/^\/[^\.\/]+\.php/', '', $path) . $fragment;
     }
 
     /**


### PR DESCRIPTION
PHP parse_url does not always return a 'path' component which causes a PHP strict error as `cleanUrl` references the array key directly in the return value. This checks for a path and defaults to root ('/') if empty.