### PR TITLE
WebAssert::addressEquals($page) should not remove query part

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -648,8 +648,9 @@ class WebAssert
     {
         $parts = parse_url($url);
         $fragment = empty($parts['fragment']) ? '' : '#' . $parts['fragment'];
+        $query = empty($parts['query']) ? '' : '?' . $parts['query'];
 
-        return preg_replace('/^\/[^\.\/]+\.php/', '', $parts['path']) . $fragment;
+        return preg_replace('/^\/[^\.\/]+\.php/', '', $parts['path']) . $query . $fragment;
     }
 
     /**

--- a/tests/WebAssertTest.php
+++ b/tests/WebAssertTest.php
@@ -26,17 +26,23 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
     public function testAddressEquals()
     {
         $this->session
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(3))
             ->method('getCurrentUrl')
             ->will($this->returnValue('http://example.com/script.php/sub/url?param=true#webapp/nav'))
         ;
 
-        $this->assertCorrectAssertion('addressEquals', array('/sub/url#webapp/nav'));
+        $this->assertCorrectAssertion('addressEquals', array('/sub/url?param=true#webapp/nav'));
+        $this->assertWrongAssertion(
+            'addressEquals',
+            array('/sub/url#webapp/nav'),
+            'Behat\\Mink\\Exception\\ExpectationException',
+            'Current page is "/sub/url?param=true#webapp/nav", but "/sub/url#webapp/nav" expected.'
+        );
         $this->assertWrongAssertion(
             'addressEquals',
             array('sub_url'),
             'Behat\\Mink\\Exception\\ExpectationException',
-            'Current page is "/sub/url#webapp/nav", but "sub_url" expected.'
+            'Current page is "/sub/url?param=true#webapp/nav", but "sub_url" expected.'
         );
     }
 


### PR DESCRIPTION
I think this is not right that I can not write something like that
```
I should be on "/login?return_url=/user"
```
in my feature context

Actually I can write, but under the hood MinkContext will remove query part from url. Interesting that it will not remove fragment part: https://github.com/Behat/Mink/blob/master/src/Behat/Mink/WebAssert.php#L647

This is copy from https://github.com/Behat/MinkExtension/issues/144