### PR TITLE
Improve the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: php
 
+sudo: false
+
 php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
-before_script:
-  - composer install --dev --prefer-source
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - composer install
 
 script: phpunit -v --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
- switch to the faster Docker-based infrastructure given that we don't need to use sudo in the build
- cache the composer cache between builds, which is possible on the new infrasture, to be able to reuse previous downloads.
- switch to use archive downloads for stable dependencies. Composer is now able to fallback to source install when the github API rate limit is reached, and the usage of the cache should avoid hitting the github API for many downloads.

note: the benefit of the cache will enter into action only after the merge. PR builds don't have their own cache when updating the PR several times. they load the cache of the target branch (and they don't save the updated cache)