### PR TITLE
Implement the conversion of XPath to NodeElement in CoreDriver

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Mink\Driver;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
 
@@ -22,11 +23,16 @@ use Behat\Mink\Session;
 abstract class CoreDriver implements DriverInterface
 {
     /**
+     * @var Session
+     */
+    private $session;
+
+    /**
      * {@inheritdoc}
      */
     public function setSession(Session $session)
     {
-        throw new UnsupportedDriverActionException('Setting the session is not supported by %s', $this);
+        $this->session = $session;
     }
 
     /**
@@ -89,6 +95,28 @@ abstract class CoreDriver implements DriverInterface
      * {@inheritdoc}
      */
     public function find($xpath)
+    {
+        $elements = array();
+
+        foreach ($this->findElementXpaths($xpath) as $xpath) {
+            $elements[] = new NodeElement($xpath, $this->session);
+        }
+
+        return $elements;
+    }
+
+    /**
+     * Finds elements with specified XPath query.
+     *
+     * @see find()
+     *
+     * @param string $xpath
+     *
+     * @return string[] The XPath of the matched elements
+     *
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     */
+    protected function findElementXpaths($xpath)
     {
         throw new UnsupportedDriverActionException('Finding elements is not supported by %s', $this);
     }

--- a/tests/Driver/CoreDriverTest.php
+++ b/tests/Driver/CoreDriverTest.php
@@ -2,6 +2,8 @@
 
 namespace Behat\Mink\Tests\Driver;
 
+use Behat\Mink\Element\NodeElement;
+
 class CoreDriverTest extends \PHPUnit_Framework_TestCase
 {
     public function testNoExtraMethods()
@@ -17,6 +19,34 @@ class CoreDriverTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testCreateNodeElements()
+    {
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\CoreDriver')
+            ->setMethods(array('findElementXpaths'))
+            ->getMockForAbstractClass();
+
+        $session = $this->getMockBuilder('Behat\Mink\Session')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $driver->setSession($session);
+
+        $driver->expects($this->once())
+            ->method('findElementXpaths')
+            ->with('xpath')
+            ->willReturn(array('xpath1', 'xpath2'));
+
+        /** @var NodeElement[] $elements */
+        $elements = $driver->find('xpath');
+
+        $this->assertInternalType('array', $elements);
+        $this->assertCount(2, $elements);
+        $this->assertContainsOnlyInstancesOf('Behat\Mink\Element\NodeElement', $elements);
+
+        $this->assertSame('xpath1', $elements[0]->getXpath());
+        $this->assertSame('xpath2', $elements[1]->getXpath());
+    }
+
     /**
      * @dataProvider getDriverInterfaceMethods
      */
@@ -28,6 +58,10 @@ class CoreDriverTest extends \PHPUnit_Framework_TestCase
             $refl->getMethod($method->getName())->isAbstract(),
             sprintf('CoreDriver should implement a dummy %s method', $method->getName())
         );
+
+        if ('setSession' === $method->getName()) {
+            return; // setSession is actually implemented, so we don't expect an exception here.
+        }
 
         $driver = $this->getMockForAbstractClass('Behat\Mink\Driver\CoreDriver');
 


### PR DESCRIPTION
The goal is to ease the development of Mink 2.0 by allowing drivers to be compatible with both Mink 1.7 and 2.0 on a single code base. The only change required for drivers is now handled at the level of the CoreDriver shipped in Mink when drivers should to override findElements rather than find (see https://github.com/minkphp/MinkZombieDriver/pull/58/files for what is required currently).
This will allow decoupling the 2.0 version of Mink from a new major version of drivers (the new major version of ZombieDriver should rather be related to the full rewrite suggested in https://github.com/minkphp/MinkZombieDriver/issues/104 if it ever happens than to the Mink refactoring for instance)