### PR TITLE
Add the humbug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 phpunit.xml
 composer.lock
 vendor
+/build

--- a/humbug.json
+++ b/humbug.json
@@ -1,0 +1,12 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "build/humbuglog.txt",
+        "json": "build/humbuglog.json"
+    }
+}


### PR DESCRIPTION
This adds the configuration file to run mutation testing with Humbug. It allows to know whether our testsuite actually covers our library.
Currently, Humbug applyes 119 mutations and reports 19 of them as being escaped (i.e. not catched by tests). However this is wrong. Among these 19, 12 should be catched but there is a bug in Humbug: https://github.com/padraic/humbug/issues/71

I intentionally don't configure Travis to run them. The Humbug output needs to be analyzed by a developer to know whether the escaped mutations are relevant or no (some mutations are harmless, which will trigger false positives). Thus, Humbug does not even return a failure exit code when there are some escaped mutations (probably because of the need of a human review btw), which would make it a pain to integrate on CI).
This config file is here to make it easy to run Humbug ourselves from time to time.
