### PR TITLE
Add a slow group in the driver testsuite for slow tests

### DIFF
--- a/driver-testsuite/tests/Basic/ErrorHandlingTest.php
+++ b/driver-testsuite/tests/Basic/ErrorHandlingTest.php
@@ -4,6 +4,9 @@ namespace Behat\Mink\Tests\Driver\Basic;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
+/**
+ * @group slow
+ */
 class ErrorHandlingTest extends TestCase
 {
     const NOT_FOUND_XPATH = '//html/./invalid';

--- a/driver-testsuite/tests/Js/ChangeEventTest.php
+++ b/driver-testsuite/tests/Js/ChangeEventTest.php
@@ -4,6 +4,9 @@ namespace Behat\Mink\Tests\Driver\Js;
 
 use Behat\Mink\Tests\Driver\TestCase;
 
+/**
+ * @group slow
+ */
 class ChangeEventTest extends TestCase
 {
     /**

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -93,6 +93,9 @@ class NodeElementTest extends ElementTest
         $this->assertSame($node, $result, '->waitFor() returns node found in callback');
     }
 
+    /**
+     * @medium
+     */
     public function testWaitForTimeout()
     {
         $node = new NodeElement('some xpath', $this->session);


### PR DESCRIPTION
Closes #576.

It also make the unit tests pass in strict mode for execution timeouts (not the driver testsuite. Execution times depend too much on the driver being used and PHPUnit execution timeouts are not really suited for functional tests IMO)