### PR TITLE
Fixed WebAssert::cleanUrl assuming front controller

### DIFF
--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -750,7 +750,7 @@ class WebAssert
         $fragment = empty($parts['fragment']) ? '' : '#'.$parts['fragment'];
         $path = empty($parts['path']) ? '/' : $parts['path'];
 
-        return preg_replace('/^\/[^\.\/]+\.php/', '', $path).$fragment;
+        return preg_replace('/^\/[^\.\/]+\.php\//', '/', $path).$fragment;
     }
 
     /**

--- a/tests/WebAssertTest.php
+++ b/tests/WebAssertTest.php
@@ -52,6 +52,23 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         $this->assertCorrectAssertion('addressEquals', array('/'));
     }
 
+    public function testAddressEqualsEndingInScript()
+    {
+        $this->session
+            ->expects($this->exactly(2))
+            ->method('getCurrentUrl')
+            ->will($this->returnValue('http://example.com/script.php'))
+        ;
+
+        $this->assertCorrectAssertion('addressEquals', array('/script.php'));
+        $this->assertWrongAssertion(
+            'addressEquals',
+            array('/'),
+            'Behat\\Mink\\Exception\\ExpectationException',
+            'Current page is "/script.php", but "/" expected.'
+        );
+    }
+
     public function testAddressNotEquals()
     {
         $this->session
@@ -66,6 +83,23 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
             array('/sub/url'),
             'Behat\\Mink\\Exception\\ExpectationException',
             'Current page is "/sub/url", but should not be.'
+        );
+    }
+
+    public function testAddressNotEqualsEndingInScript()
+    {
+        $this->session
+            ->expects($this->exactly(2))
+            ->method('getCurrentUrl')
+            ->will($this->returnValue('http://example.com/script.php'))
+        ;
+
+        $this->assertCorrectAssertion('addressNotEquals', array('/'));
+        $this->assertWrongAssertion(
+            'addressNotEquals',
+            array('/script.php'),
+            'Behat\\Mink\\Exception\\ExpectationException',
+            'Current page is "/script.php", but should not be.'
         );
     }
 


### PR DESCRIPTION
We're using Behat to test a PHP application that is not currently using any framework. We have a simple test where we use a button to navigate from one page to another. e.g. from /page1.php to /page2.php

The button is currently broken, and does not actually leave /page1.php, but when we use `Then I should be on "/page2.php"`  the test passes even though we are still on /page1.php.

We have narrowed this down to the cleanUrl() calls in WebAssert::addressEquals and WebAssert::getCurrentUrlPath, which seems to be stripping out the php script. The only reason I can think of for Mink to do this is that it's assuming the script is a front controller.

Please let me know if I'm not understanding this correctly. If I am, I believe this pull request should resolve the issue.

Thanks.