### PR TITLE
Silence deprecations by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         "symfony/css-selector":  "~2.0"
     },
 
+    "require-dev": {
+        "symfony/phpunit-bridge": "~2.7"
+    },
+
     "suggest": {
         "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
         "behat/mink-goutte-driver":     "fast headless driver for any app without JS emulation",

--- a/src/Selector/NamedSelector.php
+++ b/src/Selector/NamedSelector.php
@@ -249,7 +249,7 @@ XPATH
             || (false !== strpos($locator, '\'') && preg_match('/^"[^"]*+"$/', $locator))
             || ((8 < $length = strlen($locator)) && 'concat(' === substr($locator, 0, 7) && ')' === $locator[$length - 1])
         ) {
-            trigger_error(
+            @trigger_error(
                 'Passing an escaped locator to the named selector is deprecated as of 1.7 and will be removed in 2.0.'
                 .' Pass the raw value instead.',
                 E_USER_DEPRECATED

--- a/src/Selector/SelectorsHandler.php
+++ b/src/Selector/SelectorsHandler.php
@@ -75,7 +75,7 @@ class SelectorsHandler
     public function getSelector($name)
     {
         if ('named' === $name) {
-            trigger_error(
+            @trigger_error(
                 'Using the "named" selector directly from the handler is deprecated as of 1.6 and will be removed in 2.0.'
                 .' Use the "named_partial" or use the "named" selector through the Element API instead.',
                 E_USER_DEPRECATED
@@ -123,7 +123,7 @@ class SelectorsHandler
      */
     public function xpathLiteral($s)
     {
-        trigger_error(
+        @trigger_error(
             'The '.__METHOD__.' method is deprecated as of 1.7 and will be removed in 2.0.'
             .' Use \Behat\Mink\Selector\Xpath\Escaper::escapeLiteral instead when building Xpath'
             .' or pass the unescaped value when using the named selector.',

--- a/tests/Selector/NamedSelectorTest.php
+++ b/tests/Selector/NamedSelectorTest.php
@@ -54,14 +54,13 @@ abstract class NamedSelectorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getSelectorTests
+     * @group legacy
      */
     public function testEscapedSelectors($fixtureFile, $selector, $locator, $expectedExactCount, $expectedPartialCount = null)
     {
         // Escape the locator as Mink 1.x expects the caller of the NamedSelector to handle it
         $escaper = new Escaper();
         $locator = $escaper->escapeLiteral($locator);
-
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
 
         $this->testSelectors($fixtureFile, $selector, $locator, $expectedExactCount, $expectedPartialCount);
     }

--- a/tests/Selector/SelectorsHandlerTest.php
+++ b/tests/Selector/SelectorsHandlerTest.php
@@ -71,23 +71,25 @@ class SelectorsHandlerTest extends \PHPUnit_Framework_TestCase
         $handler->selectorToXpath('undefined', 'asd');
     }
 
+    /**
+     * @group legacy
+     */
     public function testXpathLiteral()
     {
         $handler = new SelectorsHandler();
 
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
-
         $this->assertEquals("'some simple string'", $handler->xpathLiteral('some simple string'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testBcLayer()
     {
         $selector = $this->getMockBuilder('Behat\Mink\Selector\SelectorInterface')->getMock();
         $handler = new SelectorsHandler();
 
         $handler->registerSelector('named_partial', $selector);
-
-        $this->iniSet('error_reporting', -1 & ~E_USER_DEPRECATED);
 
         $this->assertSame($selector, $handler->getSelector('named'));
     }


### PR DESCRIPTION
This follows the Symfony convention to make our deprecation warning less invasive (PHPUnit and Behat are both triggering exceptions on deprecation errors by default, thus breaking the BC layers).
Such deprecations warnings can be logged when using the Symfony error handler or the Symfony PHPUnit bridge (or other tools implementing the same convention).

There is no such tool for Behat yet, but this is on my TODO list.