### PR TITLE
Remove the dependency on the Session in expectation exceptions

### DIFF
--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -68,7 +68,7 @@ abstract class Element implements ElementInterface
      */
     public function getSession()
     {
-        @trigger_error(sprintf('The method %s is deprecated as of 1.7 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The method %s is deprecated as of 1.6 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
 
         return $this->session;
     }
@@ -202,9 +202,13 @@ abstract class Element implements ElementInterface
      * @param string|null $locator
      *
      * @return ElementNotFoundException
+     *
+     * @deprecated as of 1.7, to be removed in 2.0
      */
     protected function elementNotFound($type, $selector = null, $locator = null)
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.7 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
+
         return new ElementNotFoundException($this->driver, $type, $selector, $locator);
     }
 }

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -197,9 +197,6 @@ abstract class Element implements ElementInterface
     /**
      * Builds an ElementNotFoundException
      *
-     * This is an helper to build the ElementNotFoundException without
-     * needing to use the deprecated getSession accessor in child classes.
-     *
      * @param string      $type
      * @param string|null $selector
      * @param string|null $locator
@@ -208,6 +205,6 @@ abstract class Element implements ElementInterface
      */
     protected function elementNotFound($type, $selector = null, $locator = null)
     {
-        return new ElementNotFoundException($this->session, $type, $selector, $locator);
+        return new ElementNotFoundException($this->driver, $type, $selector, $locator);
     }
 }

--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -231,7 +231,7 @@ class NodeElement extends TraversableElement
         $opt = $this->find('named', array('option', $option));
 
         if (null === $opt) {
-            throw $this->elementNotFound('select option', 'value|text', $option);
+            throw new ElementNotFoundException($this->getDriver(), 'select option', 'value|text', $option);
         }
 
         $this->getDriver()->selectOption($this->getXpath(), $opt->getValue(), $multiple);

--- a/src/Element/TraversableElement.php
+++ b/src/Element/TraversableElement.php
@@ -67,7 +67,7 @@ abstract class TraversableElement extends Element
         $link = $this->findLink($locator);
 
         if (null === $link) {
-            throw $this->elementNotFound('link', 'id|title|alt|text', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'link', 'id|title|alt|text', $locator);
         }
 
         $link->click();
@@ -109,7 +109,7 @@ abstract class TraversableElement extends Element
         $button = $this->findButton($locator);
 
         if (null === $button) {
-            throw $this->elementNotFound('button', 'id|name|title|alt|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'button', 'id|name|title|alt|value', $locator);
         }
 
         $button->press();
@@ -154,7 +154,7 @@ abstract class TraversableElement extends Element
         $field = $this->findField($locator);
 
         if (null === $field) {
-            throw $this->elementNotFound('form field', 'id|name|label|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value', $locator);
         }
 
         $field->setValue($value);
@@ -204,7 +204,7 @@ abstract class TraversableElement extends Element
         $field = $this->findField($locator);
 
         if (null === $field) {
-            throw $this->elementNotFound('form field', 'id|name|label|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value', $locator);
         }
 
         $field->check();
@@ -222,7 +222,7 @@ abstract class TraversableElement extends Element
         $field = $this->findField($locator);
 
         if (null === $field) {
-            throw $this->elementNotFound('form field', 'id|name|label|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value', $locator);
         }
 
         $field->uncheck();
@@ -256,7 +256,7 @@ abstract class TraversableElement extends Element
         $field = $this->findField($locator);
 
         if (null === $field) {
-            throw $this->elementNotFound('form field', 'id|name|label|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value', $locator);
         }
 
         $field->selectOption($value, $multiple);
@@ -289,7 +289,7 @@ abstract class TraversableElement extends Element
         $field = $this->findField($locator);
 
         if (null === $field) {
-            throw $this->elementNotFound('form field', 'id|name|label|value', $locator);
+            throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value', $locator);
         }
 
         $field->attachFile($path);

--- a/src/Exception/ElementHtmlException.php
+++ b/src/Exception/ElementHtmlException.php
@@ -10,8 +10,9 @@
 
 namespace Behat\Mink\Exception;
 
-use Behat\Mink\Session;
+use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Element\Element;
+use Behat\Mink\Session;
 
 /**
  * Exception thrown when an expectation on the HTML of an element fails.
@@ -30,16 +31,16 @@ class ElementHtmlException extends ExpectationException
     /**
      * Initializes exception.
      *
-     * @param string     $message   optional message
-     * @param Session    $session   session instance
-     * @param Element    $element   element
-     * @param \Exception $exception expectation exception
+     * @param string                  $message   optional message
+     * @param DriverInterface|Session $driver    driver instance
+     * @param Element                 $element   element
+     * @param \Exception              $exception expectation exception
      */
-    public function __construct($message, Session $session, Element $element, \Exception $exception = null)
+    public function __construct($message, $driver, Element $element, \Exception $exception = null)
     {
         $this->element = $element;
 
-        parent::__construct($message, $session, $exception);
+        parent::__construct($message, $driver, $exception);
     }
 
     protected function getContext()

--- a/src/Exception/ElementNotFoundException.php
+++ b/src/Exception/ElementNotFoundException.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Mink\Exception;
 
+use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Session;
 
 /**
@@ -22,12 +23,12 @@ class ElementNotFoundException extends ExpectationException
     /**
      * Initializes exception.
      *
-     * @param Session $session  session instance
-     * @param string  $type     element type
-     * @param string  $selector element selector type
-     * @param string  $locator  element locator
+     * @param DriverInterface|Session $driver   driver instance
+     * @param string                  $type     element type
+     * @param string                  $selector element selector type
+     * @param string                  $locator  element locator
      */
-    public function __construct(Session $session, $type = null, $selector = null, $locator = null)
+    public function __construct($driver, $type = null, $selector = null, $locator = null)
     {
         $message = '';
 
@@ -48,6 +49,6 @@ class ElementNotFoundException extends ExpectationException
 
         $message .= ' not found.';
 
-        parent::__construct($message, $session);
+        parent::__construct($message, $driver);
     }
 }

--- a/src/Exception/ExpectationException.php
+++ b/src/Exception/ExpectationException.php
@@ -10,6 +10,7 @@
 
 namespace Behat\Mink\Exception;
 
+use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Session;
 
 /**
@@ -22,17 +23,28 @@ use Behat\Mink\Session;
 class ExpectationException extends Exception
 {
     private $session;
+    private $driver;
 
     /**
      * Initializes exception.
      *
-     * @param string     $message   optional message
-     * @param Session    $session   session instance
-     * @param \Exception $exception expectation exception
+     * @param string                  $message   optional message
+     * @param DriverInterface|Session $driver    driver instance (or session for BC)
+     * @param \Exception|null         $exception expectation exception
      */
-    public function __construct($message, Session $session, \Exception $exception = null)
+    public function __construct($message, $driver, \Exception $exception = null)
     {
-        $this->session = $session;
+        if ($driver instanceof Session) {
+            @trigger_error('Passing a Session object to the ExpectationException constructor is deprecated as of Mink 1.7. Pass the driver instead.', E_USER_DEPRECATED);
+
+            $this->session = $driver;
+            $this->driver = $driver->getDriver();
+        } elseif (!$driver instanceof DriverInterface) {
+            // Trigger an exception as we cannot typehint a disjunction
+            throw new \InvalidArgumentException('The ExpectationException constructor expects a DriverInterface or a Session.');
+        } else {
+            $this->driver = $driver;
+        }
 
         if (!$message && null !== $exception) {
             $message = $exception->getMessage();
@@ -65,16 +77,34 @@ class ExpectationException extends Exception
      */
     protected function getContext()
     {
-        return $this->trimBody($this->getSession()->getPage()->getContent());
+        return $this->trimBody($this->driver->getContent());
+    }
+
+    /**
+     * Returns driver.
+     *
+     * @return DriverInterface
+     */
+    protected function getDriver()
+    {
+        return $this->driver;
     }
 
     /**
      * Returns exception session.
      *
      * @return Session
+     *
+     * @deprecated since 1.7, to be removed in 2.0. Use getDriver and the driver API instead.
      */
     protected function getSession()
     {
+        if (null === $this->session) {
+            throw new \LogicException(sprintf('The deprecated method %s cannot be used when passing a driver in the constructor', __METHOD__));
+        }
+
+        @trigger_error(sprintf('The method %s is deprecated as of Mink 1.7 and will be removed in 2.0. Use getDriver and the driver API instead.'));
+
         return $this->session;
     }
 
@@ -130,15 +160,15 @@ class ExpectationException extends Exception
      */
     protected function getResponseInfo()
     {
-        $driver = basename(str_replace('\\', '/', get_class($this->session->getDriver())));
+        $driver = basename(str_replace('\\', '/', get_class($this->driver)));
 
         $info = '+--[ ';
         try {
-            $info .= 'HTTP/1.1 '.$this->session->getStatusCode().' | ';
+            $info .= 'HTTP/1.1 '.$this->driver->getStatusCode().' | ';
         } catch (UnsupportedDriverActionException $e) {
             // Ignore the status code when not supported
         }
-        $info .= $this->session->getCurrentUrl().' | '.$driver." ]\n|\n";
+        $info .= $this->driver->getCurrentUrl().' | '.$driver." ]\n|\n";
 
         return $info;
     }

--- a/src/Exception/ResponseTextException.php
+++ b/src/Exception/ResponseTextException.php
@@ -19,6 +19,6 @@ class ResponseTextException extends ExpectationException
 {
     protected function getContext()
     {
-        return $this->getSession()->getPage()->getText();
+        return $this->getDriver()->getText('//html');
     }
 }

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -417,7 +417,7 @@ class WebAssert
                 $selector = implode(' ', $selector);
             }
 
-            throw new ElementNotFoundException($this->session, 'element', $selectorType, $selector);
+            throw new ElementNotFoundException($this->session->getDriver(), 'element', $selectorType, $selector);
         }
 
         return $node;
@@ -635,7 +635,7 @@ class WebAssert
         $node = $container->findField($field);
 
         if (null === $node) {
-            throw new ElementNotFoundException($this->session, 'form field', 'id|name|label|value', $field);
+            throw new ElementNotFoundException($this->session->getDriver(), 'form field', 'id|name|label|value', $field);
         }
 
         return $node;
@@ -767,7 +767,7 @@ class WebAssert
             return;
         }
 
-        throw new ExpectationException($message, $this->session);
+        throw new ExpectationException($message, $this->session->getDriver());
     }
 
     /**
@@ -784,7 +784,7 @@ class WebAssert
             return;
         }
 
-        throw new ResponseTextException($message, $this->session);
+        throw new ResponseTextException($message, $this->session->getDriver());
     }
 
     /**
@@ -802,7 +802,7 @@ class WebAssert
             return;
         }
 
-        throw new ElementHtmlException($message, $this->session, $element);
+        throw new ElementHtmlException($message, $this->session->getDriver(), $element);
     }
 
     /**
@@ -820,7 +820,7 @@ class WebAssert
             return;
         }
 
-        throw new ElementTextException($message, $this->session, $element);
+        throw new ElementTextException($message, $this->session->getDriver(), $element);
     }
 
     /**

--- a/tests/Exception/ElementHtmlExceptionTest.php
+++ b/tests/Exception/ElementHtmlExceptionTest.php
@@ -11,14 +11,10 @@ class ElementHtmlExceptionTest extends \PHPUnit_Framework_TestCase
         $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
         $element = $this->getElementMock();
 
-        $session = $this->getSessionMock();
-        $session->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getStatusCode')
             ->will($this->returnValue(200));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getCurrentUrl')
             ->will($this->returnValue('http://localhost/test'));
 
@@ -40,16 +36,9 @@ TXT;
 
         $expected = sprintf($expected.'  ', get_class($driver));
 
-        $exception = new ElementHtmlException('Html error', $session, $element);
+        $exception = new ElementHtmlException('Html error', $driver, $element);
 
         $this->assertEquals($expected, $exception->__toString());
-    }
-
-    private function getSessionMock()
-    {
-        return $this->getMockBuilder('Behat\Mink\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
     }
 
     private function getElementMock()

--- a/tests/Exception/ElementNotFoundExceptionTest.php
+++ b/tests/Exception/ElementNotFoundExceptionTest.php
@@ -11,11 +11,9 @@ class ElementNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildMessage($message, $type, $selector = null, $locator = null)
     {
-        $session = $this->getMockBuilder('Behat\Mink\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
 
-        $exception = new ElementNotFoundException($session, $type, $selector, $locator);
+        $exception = new ElementNotFoundException($driver, $type, $selector, $locator);
 
         $this->assertEquals($message, $exception->getMessage());
     }
@@ -30,5 +28,23 @@ class ElementNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
             array('Field matching xpath "foobar" not found.', 'Field', 'xpath', 'foobar'),
             array('Tag with name "foobar" not found.', null, 'name', 'foobar'),
         );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testConstructWithSession()
+    {
+        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $session = $this->getMockBuilder('Behat\Mink\Session')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $session->expects($this->any())
+            ->method('getDriver')
+            ->will($this->returnValue($driver));
+
+        $exception = new ElementNotFoundException($session);
+
+        $this->assertEquals('Tag not found.', $exception->getMessage());
     }
 }

--- a/tests/Exception/ElementTextExceptionTest.php
+++ b/tests/Exception/ElementTextExceptionTest.php
@@ -11,14 +11,10 @@ class ElementTextExceptionTest extends \PHPUnit_Framework_TestCase
         $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
         $element = $this->getElementMock();
 
-        $session = $this->getSessionMock();
-        $session->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getStatusCode')
             ->will($this->returnValue(200));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getCurrentUrl')
             ->will($this->returnValue('http://localhost/test'));
 
@@ -38,16 +34,9 @@ TXT;
 
         $expected = sprintf($expected.'  ', get_class($driver));
 
-        $exception = new ElementTextException('Text error', $session, $element);
+        $exception = new ElementTextException('Text error', $driver, $element);
 
         $this->assertEquals($expected, $exception->__toString());
-    }
-
-    private function getSessionMock()
-    {
-        return $this->getMockBuilder('Behat\Mink\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
     }
 
     private function getElementMock()

--- a/tests/Exception/ResponseTextExceptionTest.php
+++ b/tests/Exception/ResponseTextExceptionTest.php
@@ -9,24 +9,16 @@ class ResponseTextExceptionTest extends \PHPUnit_Framework_TestCase
     public function testExceptionToString()
     {
         $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
-        $page = $this->getPageMock();
 
-        $session = $this->getSessionMock();
-        $session->expects($this->any())
-            ->method('getDriver')
-            ->will($this->returnValue($driver));
-        $session->expects($this->any())
-            ->method('getPage')
-            ->will($this->returnValue($page));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getStatusCode')
             ->will($this->returnValue(200));
-        $session->expects($this->any())
+        $driver->expects($this->any())
             ->method('getCurrentUrl')
             ->will($this->returnValue('http://localhost/test'));
-
-        $page->expects($this->any())
+        $driver->expects($this->any())
             ->method('getText')
+            ->with('//html')
             ->will($this->returnValue("Hello world\nTest\n"));
 
         $expected = <<<'TXT'
@@ -41,22 +33,8 @@ TXT;
 
         $expected = sprintf($expected.'  ', get_class($driver));
 
-        $exception = new ResponseTextException('Text error', $session);
+        $exception = new ResponseTextException('Text error', $driver);
 
         $this->assertEquals($expected, $exception->__toString());
-    }
-
-    private function getSessionMock()
-    {
-        return $this->getMockBuilder('Behat\Mink\Session')
-            ->disableOriginalConstructor()
-            ->getMock();
-    }
-
-    private function getPageMock()
-    {
-        return $this->getMockBuilder('Behat\Mink\Element\DocumentElement')
-            ->disableOriginalConstructor()
-            ->getMock();
     }
 }

--- a/tests/WebAssertTest.php
+++ b/tests/WebAssertTest.php
@@ -21,6 +21,10 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
         $this->session = $this->getMockBuilder('Behat\\Mink\\Session')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->session->expects($this->any())
+            ->method('getDriver')
+            ->will($this->returnValue($this->getMock('Behat\Mink\Driver\DriverInterface')));
+
         $this->assert = new WebAssert($this->session);
     }
 


### PR DESCRIPTION
Injecting the Session in exceptions is now deprecated in favor of injecting the driver.

This is a backport of https://github.com/minkphp/Mink/commit/761bb7965bf13dbb360ccace87e029fbb701489b which was done as part of #542 to refactor the driver in 2.0.
Backporting it with a BC layer means we give people instantiating our exception themselves (me at work for instance) an easier upgrade path, because they can prepare things before Mink 2.0.