### PR TITLE
Add missing deprecation warnings

### DIFF
--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -68,6 +68,8 @@ abstract class Element implements ElementInterface
      */
     public function getSession()
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.7 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
+
         return $this->session;
     }
 
@@ -90,6 +92,8 @@ abstract class Element implements ElementInterface
      */
     protected function getSelectorsHandler()
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.7 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
+
         return $this->selectorsHandler;
     }
 

--- a/src/Exception/ElementException.php
+++ b/src/Exception/ElementException.php
@@ -10,6 +10,8 @@
 
 namespace Behat\Mink\Exception;
 
+@trigger_error('The class '.__NAMESPACE__.'\ElementException is deprecated as of Mink 1.6 and will be removed in 2.0', E_USER_DEPRECATED);
+
 use Behat\Mink\Element\Element;
 
 /**

--- a/tests/Element/DocumentElementTest.php
+++ b/tests/Element/DocumentElementTest.php
@@ -19,6 +19,9 @@ class DocumentElementTest extends ElementTest
         $this->document = new DocumentElement($this->session);
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetSession()
     {
         $this->assertEquals($this->session, $this->document->getSession());

--- a/tests/Exception/ElementExceptionTest.php
+++ b/tests/Exception/ElementExceptionTest.php
@@ -4,6 +4,9 @@ namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ElementException;
 
+/**
+ * @group legacy
+ */
 class ElementExceptionTest extends \PHPUnit_Framework_TestCase
 {
     public function testMessage()


### PR DESCRIPTION
This adds deprecation messages for a few deprecated APIs which were not triggering it.
It already follows the new convention of #662.