### PR TITLE
Add missing safeguards against not found elements in the driver tests

### DIFF
--- a/driver-testsuite/tests/Basic/NavigationTest.php
+++ b/driver-testsuite/tests/Basic/NavigationTest.php
@@ -12,13 +12,13 @@ class NavigationTest extends TestCase
         $this->assertEquals($this->pathTo('/redirect_destination.html'), $this->getSession()->getCurrentUrl());
     }
 
-    public function testPageControlls()
+    public function testPageControls()
     {
         $this->getSession()->visit($this->pathTo('/randomizer.php'));
-        $number1 = $this->getSession()->getPage()->find('css', '#number')->getText();
+        $number1 = $this->getAssertSession()->elementExists('css', '#number')->getText();
 
         $this->getSession()->reload();
-        $number2 = $this->getSession()->getPage()->find('css', '#number')->getText();
+        $number2 = $this->getAssertSession()->elementExists('css', '#number')->getText();
 
         $this->assertNotEquals($number1, $number2);
 

--- a/driver-testsuite/tests/Basic/TraversingTest.php
+++ b/driver-testsuite/tests/Basic/TraversingTest.php
@@ -24,20 +24,23 @@ class TraversingTest extends TestCase
 
         $page = $this->getSession()->getPage();
 
-        $this->assertNotNull($page->find('css', 'h1'));
-        $this->assertEquals('Extremely useless page', $page->find('css', 'h1')->getText());
-        $this->assertEquals('h1', $page->find('css', 'h1')->getTagName());
+        $title = $page->find('css', 'h1');
+        $this->assertNotNull($title);
+        $this->assertEquals('Extremely useless page', $title->getText());
+        $this->assertEquals('h1', $title->getTagName());
 
-        $this->assertNotNull($page->find('xpath', '//div/strong[3]'));
-        $this->assertEquals('pariatur', $page->find('xpath', '//div/strong[3]')->getText());
-        $this->assertEquals('super-duper', $page->find('xpath', '//div/strong[3]')->getAttribute('class'));
-        $this->assertTrue($page->find('xpath', '//div/strong[3]')->hasAttribute('class'));
+        $strong = $page->find('xpath', '//div/strong[3]');
+        $this->assertNotNull($strong);
+        $this->assertEquals('pariatur', $strong->getText());
+        $this->assertEquals('super-duper', $strong->getAttribute('class'));
+        $this->assertTrue($strong->hasAttribute('class'));
 
-        $this->assertNotNull($page->find('xpath', '//div/strong[2]'));
-        $this->assertEquals('veniam', $page->find('xpath', '//div/strong[2]')->getText());
-        $this->assertEquals('strong', $page->find('xpath', '//div/strong[2]')->getTagName());
-        $this->assertNull($page->find('xpath', '//div/strong[2]')->getAttribute('class'));
-        $this->assertFalse($page->find('xpath', '//div/strong[2]')->hasAttribute('class'));
+        $strong2 = $page->find('xpath', '//div/strong[2]');
+        $this->assertNotNull($strong2);
+        $this->assertEquals('veniam', $strong2->getText());
+        $this->assertEquals('strong', $strong2->getTagName());
+        $this->assertNull($strong2->getAttribute('class'));
+        $this->assertFalse($strong2->hasAttribute('class'));
 
         $strongs = $page->findAll('css', 'div#core > strong');
         $this->assertCount(3, $strongs);
@@ -46,6 +49,7 @@ class TraversingTest extends TestCase
 
         $element = $page->find('css', '#some-element');
 
+        $this->assertNotNull($element);
         $this->assertEquals('some very interesting text', $element->getText());
         $this->assertEquals(
             "\n            some <div>very\n            </div>\n".
@@ -105,12 +109,11 @@ class TraversingTest extends TestCase
     {
         $this->getSession()->visit($this->pathTo('/index.html'));
 
-        $traversDiv = $this->getSession()->getPage()->findAll('css', 'div.travers');
+        $traversDivs = $this->getSession()->getPage()->findAll('css', 'div.travers');
 
-        $this->assertCount(1, $traversDiv);
-        $traversDiv = $traversDiv[0];
+        $this->assertCount(1, $traversDivs);
 
-        $subDivs = $traversDiv->findAll('css', 'div.sub');
+        $subDivs = $traversDivs[0]->findAll('css', 'div.sub');
         $this->assertCount(3, $subDivs);
 
         $this->assertTrue($subDivs[2]->hasLink('some deep url'));

--- a/driver-testsuite/tests/Js/ChangeEventTest.php
+++ b/driver-testsuite/tests/Js/ChangeEventTest.php
@@ -22,7 +22,7 @@ class ChangeEventTest extends TestCase
         $session->getPage()->selectFieldOption('foo_select', 'Option 3');
 
         $session->wait(2000, '$("#output_foo_select").text() != ""');
-        $this->assertEquals('onChangeSelect', $session->getPage()->find('css', '#output_foo_select')->getText());
+        $this->assertEquals('onChangeSelect', $this->getAssertSession()->elementExists('css', '#output_foo_select')->getText());
     }
 
     public function testIssue178()

--- a/driver-testsuite/tests/Js/JavascriptEvaluationTest.php
+++ b/driver-testsuite/tests/Js/JavascriptEvaluationTest.php
@@ -25,11 +25,11 @@ class JavascriptEvaluationTest extends TestCase
 
         $waitable->click();
         $this->getSession()->wait(3000, '$("#waitable").has("div").length > 0');
-        $this->assertEquals('arrived', $this->getSession()->getPage()->find('css', '#waitable > div')->getText());
+        $this->assertEquals('arrived', $this->getAssertSession()->elementExists('css', '#waitable > div')->getText());
 
         $waitable->click();
         $this->getSession()->wait(3000, 'false');
-        $this->assertEquals('timeout', $this->getSession()->getPage()->find('css', '#waitable > div')->getText());
+        $this->assertEquals('timeout', $this->getAssertSession()->elementExists('css', '#waitable > div')->getText());
     }
 
     /**

--- a/driver-testsuite/tests/Js/JavascriptTest.php
+++ b/driver-testsuite/tests/Js/JavascriptTest.php
@@ -27,7 +27,7 @@ class JavascriptTest extends TestCase
         $droppable = $webAssert->elementExists('css', '#droppable');
 
         $draggable->dragTo($droppable);
-        $this->assertEquals('Dropped!', $droppable->find('css', 'p')->getText());
+        $this->assertEquals('Dropped!', $this->getAssertSession()->elementExists('css', 'p', $droppable)->getText());
     }
 
     // test accentuated char in button


### PR DESCRIPTION
See https://travis-ci.org/minkphp/MinkZombieDriver/jobs/77806886 for a build triggering a fatal error when failing to find an element