### PR TITLE
Add a test ensuring that drivers follow conventions

### DIFF
--- a/driver-testsuite/tests/Basic/BestPracticesTest.php
+++ b/driver-testsuite/tests/Basic/BestPracticesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Basic;
+
+use Behat\Mink\Tests\Driver\TestCase;
+
+/**
+ * This testcase ensures that the driver implementation follows recommended practices for drivers.
+ */
+class BestPracticesTest extends TestCase
+{
+    public function testExtendsCoreDriver()
+    {
+        $driver = $this->createDriver();
+
+        $this->assertInstanceOf('Behat\Mink\Driver\CoreDriver', $driver);
+
+        return $driver;
+    }
+
+    /**
+     * @depends testExtendsCoreDriver
+     */
+    public function testImplementFindXpath()
+    {
+        $driver = $this->createDriver();
+
+        $this->assertNotImplementMethod('find', $driver, 'The driver should overwrite `findElementXpaths` rather than `find` for forward compatibility with Mink 2.');
+        $this->assertImplementMethod('findElementXpaths', $driver, 'The driver must be able to find elements.');
+        $this->assertNotImplementMethod('setSession', $driver, 'The driver should not deal with the Session directly for forward compatibility with Mink 2.');
+    }
+
+    /**
+     * @dataProvider provideRequiredMethods
+     */
+    public function testImplementBasicApi($method)
+    {
+        $driver = $this->createDriver();
+
+        $this->assertImplementMethod($method, $driver, 'The driver is unusable when this method is not implemented.');
+    }
+
+    public function provideRequiredMethods()
+    {
+        return array(
+            array('start'),
+            array('isStarted'),
+            array('stop'),
+            array('reset'),
+            array('visit'),
+            array('getCurrentUrl'),
+            array('getContent'),
+            array('click'),
+        );
+    }
+
+    private function assertImplementMethod($method, $object, $reason = '')
+    {
+        $ref = new \ReflectionClass(get_class($object));
+        $refMethod = $ref->getMethod($method);
+
+        $message = sprintf('The driver should implement the `%s` method.', $method);
+
+        if ('' !== $reason) {
+            $message .= ' '.$reason;
+        }
+
+        $this->assertSame($ref->name, $refMethod->getDeclaringClass()->name, $message);
+    }
+
+    private function assertNotImplementMethod($method, $object, $reason = '')
+    {
+        $ref = new \ReflectionClass(get_class($object));
+        $refMethod = $ref->getMethod($method);
+
+        $message = sprintf('The driver should not implement the `%s` method.', $method);
+
+        if ('' !== $reason) {
+            $message .= ' '.$reason;
+        }
+
+        $this->assertNotSame($ref->name, $refMethod->getDeclaringClass()->name, $message);
+    }
+}

--- a/driver-testsuite/tests/TestCase.php
+++ b/driver-testsuite/tests/TestCase.php
@@ -106,6 +106,19 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Creates a new driver instance.
+     *
+     * This driver is not associated to a session. It is meant to be used for tests on the driver
+     * implementation itself rather than test using the Mink API.
+     *
+     * @return \Behat\Mink\Driver\DriverInterface
+     */
+    protected function createDriver()
+    {
+        return self::getConfig()->createDriver();
+    }
+
+    /**
      * Map remote file path.
      *
      * @param string $file File path.


### PR DESCRIPTION
This ensures that drivers are implemented in a forward compatible way for Twig 2, and that they implement the most basic methods necessary to make the driver usable in Mink.