### PR TITLE
Fix the driver testsuite to account for driver inheritance

### DIFF
--- a/driver-testsuite/tests/Basic/BestPracticesTest.php
+++ b/driver-testsuite/tests/Basic/BestPracticesTest.php
@@ -65,7 +65,7 @@ class BestPracticesTest extends TestCase
             $message .= ' '.$reason;
         }
 
-        $this->assertSame($ref->name, $refMethod->getDeclaringClass()->name, $message);
+        $this->assertNotSame('Behat\Mink\Driver\CoreDriver', $refMethod->getDeclaringClass()->name, $message);
     }
 
     private function assertNotImplementMethod($method, $object, $reason = '')
@@ -79,6 +79,6 @@ class BestPracticesTest extends TestCase
             $message .= ' '.$reason;
         }
 
-        $this->assertNotSame($ref->name, $refMethod->getDeclaringClass()->name, $message);
+        $this->assertSame('Behat\Mink\Driver\CoreDriver', $refMethod->getDeclaringClass()->name, $message);
     }
 }


### PR DESCRIPTION
GoutteDriver extends BrowserKitDriver and so does not implement the methods directly. What we really need to check is whether the implementation comes from CoreDriver or no.

See https://travis-ci.org/minkphp/MinkGoutteDriver/builds/81313799