### PR TITLE
Add testing against dev versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   include:
     - php: 5.3
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 5.6
+      env: DEPENDENCIES=dev
   allow_failures:
     - php: 7.0
 
@@ -18,6 +20,7 @@ cache:
 
 before_install:
   - composer self-update
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
   - composer update $COMPOSER_FLAGS

--- a/src/Selector/CssSelector.php
+++ b/src/Selector/CssSelector.php
@@ -11,6 +11,7 @@
 namespace Behat\Mink\Selector;
 
 use Symfony\Component\CssSelector\CssSelector as CSS;
+use Symfony\Component\CssSelector\CssSelectorConverter;
 
 /**
  * CSS selector engine. Transforms CSS to XPath.
@@ -32,6 +33,14 @@ class CssSelector implements SelectorInterface
             throw new \InvalidArgumentException('The CssSelector expects to get a string as locator');
         }
 
+        // Symfony 2.8+ API
+        if (class_exists('Symfony\Component\CssSelector\CssSelectorConverter')) {
+            $converter = new CssSelectorConverter();
+
+            return $converter->toXPath($locator);
+        }
+
+        // old static API for Symfony 2.7 and older
         return CSS::toXPath($locator);
     }
 }

--- a/tests/Selector/CssSelectorTest.php
+++ b/tests/Selector/CssSelectorTest.php
@@ -8,7 +8,7 @@ class CssSelectorTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
+        if (!class_exists('Symfony\Component\CssSelector\CssSelectorConverter') && !class_exists('Symfony\Component\CssSelector\CssSelector')) {
             $this->markTestSkipped('Symfony2 CssSelector component not installed');
         }
     }


### PR DESCRIPTION
This adds a job in the matrix running tests against dev versions of our dependencies.
The goal is to allow us to catch failures on them before the new version of the dependency gets released (assuming we have a Travis build running of course), allowing us to prepare changes before the stable release of our dependency. This is mostly useful to catch places where the APIs we are using are getting deprecated.