### PR TITLE
Fix an instance of xss

### DIFF
--- a/driver-testsuite/web-fixtures/advanced_form_post.php
+++ b/driver-testsuite/web-fixtures/advanced_form_post.php
@@ -13,10 +13,10 @@ if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_
 }
 
 $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
+ksort($_POST);
 foreach ($_POST as $key => $value) {
-	$post_for_printing[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+	$post_for_printing[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars(var_export($value, TRUE), ENT_QUOTES, 'UTF-8');
 }
-ksort($post_for_printing);
 echo str_replace('>', '', var_export($post_for_printing, true)) . "\n";
 if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
     echo htmlspecialchars($_FILES['about']['name'], ENT_QUOTES, 'UTF-8') . "\n";

--- a/driver-testsuite/web-fixtures/advanced_form_post.php
+++ b/driver-testsuite/web-fixtures/advanced_form_post.php
@@ -14,11 +14,10 @@ if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_
 
 $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
 foreach ($_POST as $key => $value) {
-	unset($_POST[$key]);
-	$_POST[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+	$post_for_printing[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 }
-ksort($_POST);
-echo str_replace('>', '', var_export($_POST, true)) . "\n";
+ksort($post_for_printing);
+echo str_replace('>', '', var_export($post_for_printing, true)) . "\n";
 if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
     echo htmlspecialchars($_FILES['about']['name'], ENT_QUOTES, 'UTF-8') . "\n";
     echo htmlspecialchars(file_get_contents($_FILES['about']['tmp_name'], ENT_QUOTES, 'UTF-8'));

--- a/driver-testsuite/web-fixtures/advanced_form_post.php
+++ b/driver-testsuite/web-fixtures/advanced_form_post.php
@@ -13,11 +13,15 @@ if (isset($_POST['select_multiple_numbers']) && false !== strpos($_POST['select_
 }
 
 $_POST['agreement'] = isset($_POST['agreement']) ? 'on' : 'off';
+foreach ($_POST as $key => $value) {
+	unset($_POST[$key]);
+	$_POST[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
 ksort($_POST);
 echo str_replace('>', '', var_export($_POST, true)) . "\n";
 if (isset($_FILES['about']) && file_exists($_FILES['about']['tmp_name'])) {
-    echo $_FILES['about']['name'] . "\n";
-    echo file_get_contents($_FILES['about']['tmp_name']);
+    echo htmlspecialchars($_FILES['about']['name'], ENT_QUOTES, 'UTF-8') . "\n";
+    echo htmlspecialchars(file_get_contents($_FILES['about']['tmp_name'], ENT_QUOTES, 'UTF-8'));
 } else {
     echo "no file";
 }

--- a/driver-testsuite/web-fixtures/basic_form_post.php
+++ b/driver-testsuite/web-fixtures/basic_form_post.php
@@ -5,9 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
-    <h1>Anket for <?php echo $_POST['first_name'] ?></h1>
-
-    <span id="first">Firstname: <?php echo $_POST['first_name'] ?></span>
-    <span id="last">Lastname: <?php echo $_POST['last_name'] ?></span>
+    <h1>Anket for <?php echo htmlspecialchars($_POST['first_name'], ENT_QUOTES, 'UTF-8') ?></h1>
+    <span id="first">Firstname: <?php echo htmlspecialchars($_POST['first_name'], ENT_QUOTES, 'UTF-8') ?></span>
+    <span id="last">Lastname: <?php echo htmlspecialchars($_POST['last_name'], ENT_QUOTES, 'UTF-8') ?></span>
 </body>
 </html>

--- a/driver-testsuite/web-fixtures/basic_get_form.php
+++ b/driver-testsuite/web-fixtures/basic_get_form.php
@@ -8,7 +8,7 @@
     <h1>Basic Get Form Page</h1>
 
     <div id="serach">
-        <?php echo isset($_GET['q']) && $_GET['q'] ? $_GET['q'] : 'No search query' ?>
+        <?php echo isset($_GET['q']) && $_GET['q'] ? htmlspecialchars($_GET['q'], ENT_QUOTES, 'UTF-8') : 'No search query' ?>
     </div>
 
     <form>

--- a/driver-testsuite/web-fixtures/cookie_page2.php
+++ b/driver-testsuite/web-fixtures/cookie_page2.php
@@ -5,6 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
-    Previous cookie: <?php echo isset($_COOKIE['srvr_cookie']) ? $_COOKIE['srvr_cookie'] : 'NO'; ?>
+    Previous cookie: <?php echo isset($_COOKIE['srvr_cookie']) ? htmlspecialchars($_COOKIE['srvr_cookie'], ENT_QUOTES, 'UTF-8') : 'NO'; ?>
 </body>
 </html>

--- a/driver-testsuite/web-fixtures/issue130.php
+++ b/driver-testsuite/web-fixtures/issue130.php
@@ -5,7 +5,7 @@
     if ('1' === $_GET['p']) {
         echo '<a href="issue130.php?p=2">Go to 2</a>';
     } else {
-        echo '<strong>'.htmlspecialchars($_SERVER['HTTP_REFERER'], ENT_QUOTES, 'UTF-8');).'</strong>';
+        echo '<strong>'.htmlspecialchars($_SERVER['HTTP_REFERER'], ENT_QUOTES, 'UTF-8').'</strong>';
     }
     ?>
 </body>

--- a/driver-testsuite/web-fixtures/issue130.php
+++ b/driver-testsuite/web-fixtures/issue130.php
@@ -5,7 +5,7 @@
     if ('1' === $_GET['p']) {
         echo '<a href="issue130.php?p=2">Go to 2</a>';
     } else {
-        echo '<strong>'.$_SERVER['HTTP_REFERER'].'</strong>';
+        echo '<strong>'.htmlspecialchars($_SERVER['HTTP_REFERER'], ENT_QUOTES, 'UTF-8');).'</strong>';
     }
     ?>
 </body>

--- a/driver-testsuite/web-fixtures/issue140.php
+++ b/driver-testsuite/web-fixtures/issue140.php
@@ -2,7 +2,7 @@
 if (!empty($_POST)) {
     setcookie("tc", $_POST['cookie_value'], null, '/');
 } elseif (isset($_GET["show_value"])) {
-    echo $_COOKIE["tc"];
+    echo htmlspecialchars($_COOKIE["tc"],  ENT_QUOTES, 'UTF-8');
     die();
 }
 ?>

--- a/driver-testsuite/web-fixtures/print_cookies.php
+++ b/driver-testsuite/web-fixtures/print_cookies.php
@@ -7,10 +7,9 @@
 <body>
 	<?php
 	foreach ($_COOKIE as $key => $value) {
-		unset($_COOKIE[$key]);
-		$_COOKIE[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+		$cookie_for_printing[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 	}
 	?>
-    <?php echo str_replace('>', '', var_export($_COOKIE, true)); ?>
+    <?php echo str_replace('>', '', var_export($cookie_for_printing, true)); ?>
 </body>
 </html>

--- a/driver-testsuite/web-fixtures/print_cookies.php
+++ b/driver-testsuite/web-fixtures/print_cookies.php
@@ -5,6 +5,12 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
+	<?php
+	foreach ($_COOKIE as $key => $value) {
+		unset($_COOKIE[$key]);
+		$_COOKIE[htmlspecialchars($key, ENT_QUOTES, 'UTF-8')] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+	}
+	?>
     <?php echo str_replace('>', '', var_export($_COOKIE, true)); ?>
 </body>
 </html>


### PR DESCRIPTION
Hi,

There's an xss issue in https://github.com/minkphp/Mink/blob/master/driver-testsuite/web-fixtures/issue130.php

That issue was highlighted in an email to full disclosure at http://seclists.org/fulldisclosure/2015/Oct/42

The Drupal project attempts to solve this xss issue with an .htaccess file, but that's not very reliable. Another solution is to keep Mink code outside of the webroot, but that's not always possible on all servers.

It would be ideal, in my opinion, to just filter the text. 

I did a quick grep to look for other similar problems and it seems there are some:

```
 ✗ grep -r echo . | grep \$_
./driver-testsuite/web-fixtures/advanced_form_post.php:echo str_replace('>', '', var_export($_POST, true)) . "\n";
./driver-testsuite/web-fixtures/advanced_form_post.php:    echo $_FILES['about']['name'] . "\n";
./driver-testsuite/web-fixtures/advanced_form_post.php:    echo file_get_contents($_FILES['about']['tmp_name']);
./driver-testsuite/web-fixtures/basic_form_post.php:    <h1>Anket for <?php echo $_POST['first_name'] ?></h1>
./driver-testsuite/web-fixtures/basic_form_post.php:    <span id="first">Firstname: <?php echo $_POST['first_name'] ?></span>
./driver-testsuite/web-fixtures/basic_form_post.php:    <span id="last">Lastname: <?php echo $_POST['last_name'] ?></span>
./driver-testsuite/web-fixtures/basic_get_form.php:        <?php echo isset($_GET['q']) && $_GET['q'] ? $_GET['q'] : 'No search query' ?>
./driver-testsuite/web-fixtures/cookie_page2.php:    Previous cookie: <?php echo isset($_COOKIE['srvr_cookie']) ? $_COOKIE['srvr_cookie'] : 'NO'; ?>
./driver-testsuite/web-fixtures/issue130.php:        echo '<strong>'.htmlspecialchars($_SERVER['HTTP_REFERER'], ENT_QUOTES, 'UTF-8');).'</strong>';
./driver-testsuite/web-fixtures/issue140.php:    echo $_COOKIE["tc"];
./driver-testsuite/web-fixtures/print_cookies.php:    <?php echo str_replace('>', '', var_export($_COOKIE, true)); ?>
```

I didn't look into fixing any more of them.
