### PR TITLE
Revert "Add a test for cookies with semicolon"

### DIFF
--- a/driver-testsuite/tests/Basic/CookieTest.php
+++ b/driver-testsuite/tests/Basic/CookieTest.php
@@ -47,14 +47,6 @@ class CookieTest extends TestCase
         $this->assertContains('Previous cookie: NO', $this->getSession()->getPage()->getText());
     }
 
-    public function testCookieWithSemicolon()
-    {
-        $this->getSession()->setCookie('srvr_cookie', 'foo;bar;baz');
-        $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
-        $this->assertEquals('foo;bar;baz', $this->getSession()->getCookie('srvr_cookie'));
-        $this->assertContains('Previous cookie: foo;bar;baz', $this->getSession()->getPage()->getText());
-    }
-
     /**
      * @dataProvider cookieWithPathsDataProvider
      */


### PR DESCRIPTION
Reverts minkphp/Mink#675 because the semicolon isn't allowed symbol in cookie value. Quote from http://curl.haxx.se/rfc/cookie_spec.html : 

```
NAME=VALUE
This string is a sequence of characters excluding semi-colon, comma and white space. If there is a need to place such data in the name or value, some encoding method such as URL style %XX encoding is recommended, though no encoding is defined or required.
```

// cc: @dawehner 