### PR TITLE
Headless resizewindow support

### DIFF
--- a/driver-testsuite/tests/Js/WindowTest.php
+++ b/driver-testsuite/tests/Js/WindowTest.php
@@ -77,7 +77,7 @@ class WindowTest extends TestCase
           boolSizeCheck = Math.abs(y - 300) <= 100 && Math.abs(x - 400) <= 100;
           return boolSizeCheck;
         })();
-        JS;
+JS;
 
         $this->assertTrue($session->evaluateScript($jsWindowSizeScript));
     }


### PR DESCRIPTION
Full thread can be followed in https://github.com/jcalderonzumba/MinkPhantomJSDriver/pull/50

In a summary basically headless browsers as phantomjs allows to "resize" the view (not the window) so resizeWindow driver method makes sense therefore the testResizeWindows needs change in order to support both Selenium (real browser) and headless (phantomjs).
