### PR TITLE
Fix the usage of the Mink API in testCookieWithSemicolon

### DIFF
--- a/driver-testsuite/tests/Basic/CookieTest.php
+++ b/driver-testsuite/tests/Basic/CookieTest.php
@@ -49,6 +49,7 @@ class CookieTest extends TestCase
 
     public function testCookieWithSemicolon()
     {
+        $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
         $this->getSession()->setCookie('srvr_cookie', 'foo;bar;baz');
         $this->getSession()->visit($this->pathTo('/cookie_page2.php'));
         $this->assertEquals('foo;bar;baz', $this->getSession()->getCookie('srvr_cookie'));


### PR DESCRIPTION
Setting a cookie on a newly started session is an unsupported case. The behavior in drivers is undefined (some of them are failing, others are setting the cookie but without guarantee on the domain...)