### PR TITLE
Fix the compatibility of the testsuite with PHPUnit 5

### DIFF
--- a/driver-testsuite/tests/SkippingUnsupportedTestCase.php
+++ b/driver-testsuite/tests/SkippingUnsupportedTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver;
+
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+
+if (version_compare(\PHPUnit_Runner_Version::id(), '5.0.0', '>=')) {
+    /**
+     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 5+
+     *
+     * This code should be moved back to \Behat\Mink\Tests\Driver\TestCase when dropping support for
+     * PHP 5.5 and older, as PHPUnit 4 won't be needed anymore.
+     *
+     * @internal
+     */
+    class SkippingUnsupportedTestCase extends \PHPUnit_Framework_TestCase
+    {
+        protected function onNotSuccessfulTest($e)
+        {
+            if ($e instanceof UnsupportedDriverActionException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+
+            parent::onNotSuccessfulTest($e);
+        }
+    }
+} else {
+    /**
+     * Implementation of the skipping for UnsupportedDriverActionException for PHPUnit 4
+     *
+     * @internal
+     */
+    class SkippingUnsupportedTestCase extends \PHPUnit_Framework_TestCase
+    {
+        protected function onNotSuccessfulTest(\Exception $e)
+        {
+            if ($e instanceof UnsupportedDriverActionException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+
+            parent::onNotSuccessfulTest($e);
+        }
+    }
+}

--- a/driver-testsuite/tests/TestCase.php
+++ b/driver-testsuite/tests/TestCase.php
@@ -7,7 +7,7 @@ use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use Behat\Mink\WebAssert;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends SkippingUnsupportedTestCase
 {
     /**
      * Mink session manager.
@@ -64,15 +64,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         if (null !== self::$mink) {
             self::$mink->resetSessions();
         }
-    }
-
-    protected function onNotSuccessfulTest(\Exception $e)
-    {
-        if ($e instanceof UnsupportedDriverActionException) {
-            $this->markTestSkipped($e->getMessage());
-        }
-
-        parent::onNotSuccessfulTest($e);
     }
 
     /**


### PR DESCRIPTION
I created a separate class holding this logic, to avoid duplicating the whole base TestCase class, thus reducing duplication.

Closes #684