### PR TITLE
Export-ignore test files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/driver-testsuite export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+phpdoc.ini.dist export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/driver-testsuite export-ignore
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
This will exclude the tests en driver-testsuite (+ some other files) from the archives, downloaded with Composer and directly via Github. As this code is not used in production, it doesn't have to be included.

People can still use --prefer-source to get the full archive with tests etc. Should also prevent code from being run when the vendor folder is not properly protected (#677)