### PR TITLE
Fix WebAssert::fieldValue(Not)Equals

### DIFF
--- a/src/Behat/Mink/WebAssert.php
+++ b/src/Behat/Mink/WebAssert.php
@@ -558,7 +558,7 @@ class WebAssert
     }
 
     /**
-     * Checks that specific field have provided value.
+     * Checks that specific field value equals provided value.
      *
      * @param string             $field     field id|name|label|value
      * @param string             $value     field value
@@ -570,15 +570,19 @@ class WebAssert
     {
         $node   = $this->fieldExists($field, $container);
         $actual = $node->getValue();
-        $regex  = '/^'.preg_quote($value, '/').'$/ui';
 
-        $message = sprintf('The field "%s" value is "%s", but "%s" expected.', $field, $actual, $value);
+        $message = sprintf(
+            'The field "%s" value is "%s", but "%s" expected.',
+            $field,
+            (is_array($actual) ? '['.implode(', ', $actual).']' : $actual),
+            (is_array($value) ? '['.implode(', ', $value).']' : $value)
+        );
 
-        $this->assert((bool) preg_match($regex, $actual), $message);
+        $this->assert($actual === $value, $message);
     }
 
     /**
-     * Checks that specific field have provided value.
+     * Checks that specific field value not equals provided value.
      *
      * @param string             $field     field id|name|label|value
      * @param string             $value     field value
@@ -590,11 +594,14 @@ class WebAssert
     {
         $node   = $this->fieldExists($field, $container);
         $actual = $node->getValue();
-        $regex  = '/^'.preg_quote($value, '/').'$/ui';
 
-        $message = sprintf('The field "%s" value is "%s", but it should not be.', $field, $actual);
+        $message = sprintf(
+            'The field "%s" value is "%s", but it should not be.',
+            $field,
+            (is_array($actual) ? '['.implode(', ', $actual).']' : $actual)
+        );
 
-        $this->assert(!preg_match($regex, $actual), $message);
+        $this->assert($actual !== $value, $message);
     }
 
     /**


### PR DESCRIPTION
Behat/Mink/WebAssert.php, `fieldValueEquals`/`fieldValueNotEquals`:
- Replace usage of `preg_match` by `===`
- Extend comparison ability to arrays
- Add array handling to message creation
- Comparison for boolean values seems broken, but booleans are only returned by checkboxes which are more likely to be checked by `WebAssert::checkboxChecked`/`WebAssert::checkboxNotChecked`

tests/WebAssertTest.php:
- Add special handling for `PHPUnit_Framework_AssertionFailedError`:
-- PHPUnit_Framework_Assert::fail throws this exception and the test should let it pass
-- Test should catch and process all other exception
- Fix and extend tests `testFieldValueEquals` and `testFieldValueNotEquals`:
-- according to `PHPDoc Behat\Mink\Element\NodeElement::getValue` returns `string|bool|array`
-- current tests only check against integer values