### PR TITLE
Use selectOption if setValue is called on select element

### DIFF
--- a/driver-testsuite/tests/Form/GeneralTest.php
+++ b/driver-testsuite/tests/Form/GeneralTest.php
@@ -196,6 +196,9 @@ class GeneralTest extends TestCase
         $page->fillField('first_name', 'Foo "item"');
         $page->fillField('last_name', 'Bar');
         $page->fillField('Your email:', 'ever.zet@gmail.com');
+        $page->fillField('select_number', 'ten');
+        $this->assertEquals('10', $select->getValue());
+        $page->fillField('select_number', 'thirty');
 
         $this->assertEquals('Foo "item"', $firstname->getValue());
         $this->assertEquals('Bar', $lastname->getValue());

--- a/src/Element/TraversableElement.php
+++ b/src/Element/TraversableElement.php
@@ -157,7 +157,11 @@ abstract class TraversableElement extends Element
             throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value|placeholder', $locator);
         }
 
-        $field->setValue($value);
+        if ('select' === $field->getTagName()) {
+            $field->selectOption($value);
+        } else {
+            $field->setValue($value);
+        }
     }
 
     /**

--- a/tests/Element/DocumentElementTest.php
+++ b/tests/Element/DocumentElementTest.php
@@ -318,6 +318,31 @@ class DocumentElementTest extends ElementTest
         $this->document->fillField('some field', 'some val');
     }
 
+    public function testSetValueOnSelect()
+    {
+        $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node
+            ->expects($this->once())
+            ->method('getTagName')
+            ->willReturn('select');
+        $node
+            ->expects($this->once())
+            ->method('selectOption')
+            ->with('some val');
+
+        $this->mockNamedFinder(
+            '//field',
+            array($node),
+            array('field', 'some field')
+        );
+
+        $this->document->fillField('some field', 'some val');
+        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        $this->document->fillField('some field', 'some val');
+    }
+
     public function testCheckField()
     {
         $node = $this->getMockBuilder('Behat\Mink\Element\NodeElement')


### PR DESCRIPTION
This allows to use option labels when using the following syntax (currently this works with option value only):
```
  When I fill in the following:
    | Example label      | Example label  |
```