### PR TITLE
Provide partial named selector that selects also the hidden fields

### DIFF
--- a/src/Selector/PartialNamedIncludingHiddenSelector.php
+++ b/src/Selector/PartialNamedIncludingHiddenSelector.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Mink package.
+ * (c) Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Behat\Mink\Selector;
+
+/**
+ * Named selectors engine. Uses registered XPath selectors to create new expressions.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class PartialNamedIncludingHiddenSelector extends PartialNamedSelector
+{
+    public function __construct()
+    {
+        $this->registerReplacement('%notFieldTypeFilter%', "not(%buttonTypeFilter%)");
+
+        parent::__construct();
+    }
+}


### PR DESCRIPTION
Sometimes we have to search for hidden fields (`<input type="hidden" .../>`). Add this selector to be used for such cases.