### PR TITLE
Modifiying header test due to limitations found on PhantomJS

### DIFF
--- a/driver-testsuite/tests/Basic/HeaderTest.php
+++ b/driver-testsuite/tests/Basic/HeaderTest.php
@@ -25,7 +25,7 @@ class HeaderTest extends TestCase
         $this->getSession()->setRequestHeader('Accept-Language', 'fr');
         $this->getSession()->visit($this->pathTo('/headers.php'));
 
-        $this->assertContains('[HTTP_ACCEPT_LANGUAGE] => fr', $this->getSession()->getPage()->getContent());
+        $this->assertContains('HTTP_ACCEPT_LANGUAGE=fr', $this->getSession()->getPage()->getContent());
     }
 
     public function testSetUserAgent()
@@ -34,7 +34,7 @@ class HeaderTest extends TestCase
 
         $session->setRequestHeader('user-agent', 'foo bar');
         $session->visit($this->pathTo('/headers.php'));
-        $this->assertContains('[HTTP_USER_AGENT] => foo bar', $session->getPage()->getContent());
+        $this->assertContains('HTTP_USER_AGENT=foo bar', $session->getPage()->getContent());
     }
 
     public function testResetHeaders()
@@ -45,7 +45,7 @@ class HeaderTest extends TestCase
         $session->visit($this->pathTo('/headers.php'));
 
         $this->assertContains(
-            '[HTTP_X_MINK_TEST] => test',
+            'HTTP_X_MINK_TEST=test',
             $session->getPage()->getContent(),
             'The custom header should be sent',
             true
@@ -55,7 +55,7 @@ class HeaderTest extends TestCase
         $session->visit($this->pathTo('/headers.php'));
 
         $this->assertNotContains(
-            '[HTTP_X_MINK_TEST] => test',
+            'HTTP_X_MINK_TEST=test',
             $session->getPage()->getContent(),
             'The custom header should not be sent after resetting',
             true

--- a/driver-testsuite/web-fixtures/headers.php
+++ b/driver-testsuite/web-fixtures/headers.php
@@ -5,6 +5,10 @@
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
 </head>
 <body>
-    <?php print_r($_SERVER); ?>
+<?php
+foreach($_SERVER as $serverKey => $serverValue){
+  echo sprintf("<p>%s=%s</p>", $serverKey, $serverValue);
+}
+?>
 </body>
 </html>


### PR DESCRIPTION
The purpose of this changes relates to the way headers test is being done.

PhantomJS only way to get the page HTML is via http://phantomjs.org/api/webpage/property/frame-content.html method and this is a know thing of phantomjs, it DOES changes the original HTML therefore in phantomjs drivers (https://github.com/jcalderonzumba/MinkPhantomJSDriver) test fails because the array "=>" changes to "=&gt".

Also in my personal opinion the test was a bit basic doing just a "dump" of $_SERVER global variable using print_r. In this PR it is changed to generate a "proper html" adding a 
`<p>/<p>` for each item of $_SERVER.

This is also part of the process to make this driver an official driver of Mink.
