### PR TITLE
Allow pipes (|) in attributes by implementing better XPath parsing

### DIFF
--- a/src/Selector/Xpath/Manipulator.php
+++ b/src/Selector/Xpath/Manipulator.php
@@ -74,12 +74,12 @@ class Manipulator
      *
      * @return string[]
      */
-    protected function splitUnionParts($xpath)
+    private function splitUnionParts($xpath)
     {
         // Split any unions into individual expressions. We need to iterate
         // through the string to correctly parse opening/closing quotes and
         // braces which is not possible with regular expressions.
-        $union_parts = array();
+        $unionParts = array();
         $singleQuoteOpen = false;
         $doubleQuoteOpen = false;
         $bracketOpen = 0;
@@ -103,13 +103,13 @@ class Manipulator
                 } else if ($xpath{$i} === ']') {
                     $bracketOpen--;
                 } else if ($xpath{$i} === '|' && $bracketOpen === 0) {
-                    $union_parts[] = substr($xpath, $lastUnion, $i - $lastUnion);
+                    $unionParts[] = substr($xpath, $lastUnion, $i - $lastUnion);
                     $lastUnion = $i + 1;
                 }
             }
         }
-        $union_parts[] = substr($xpath, $lastUnion);
-        return $union_parts;
+        $unionParts[] = substr($xpath, $lastUnion);
+        return $unionParts;
     }
 
 }

--- a/src/Selector/Xpath/Manipulator.php
+++ b/src/Selector/Xpath/Manipulator.php
@@ -87,11 +87,11 @@ class Manipulator
         for ($i = 0; $i < strlen($xpath); $i++) {
             $char = $xpath[$i];
 
-            if ($char === "'" && $inDoubleQuotedString === false) {
+            if ($char === "'" && !$inDoubleQuotedString) {
                 $inSingleQuotedString = !$inSingleQuotedString;
-            } elseif ($char === '"' && $inSingleQuotedString === false) {
+            } elseif ($char === '"' && !$inSingleQuotedString) {
                 $inDoubleQuotedString = !$inDoubleQuotedString;
-            } elseif ($inSingleQuotedString === false && $inDoubleQuotedString === false) {
+            } elseif (!$inSingleQuotedString && !$inDoubleQuotedString) {
                 if ($char === '[') {
                     $openedBrackets++;
                 } elseif ($char === ']') {

--- a/src/Selector/Xpath/Manipulator.php
+++ b/src/Selector/Xpath/Manipulator.php
@@ -80,29 +80,23 @@ class Manipulator
         // through the string to correctly parse opening/closing quotes and
         // braces which is not possible with regular expressions.
         $unionParts = array();
-        $singleQuoteOpen = false;
-        $doubleQuoteOpen = false;
-        $bracketOpen = 0;
+        $inSingleQuotedString = false;
+        $inDoubleQuotedString = false;
+        $openedBrackets = 0;
         $lastUnion = 0;
         for ($i = 0; $i < strlen($xpath); $i++) {
-            if ($xpath{$i} === "'" && $doubleQuoteOpen === false) {
-                if ($singleQuoteOpen === true) {
-                    $singleQuoteOpen = false;
-                } else {
-                    $singleQuoteOpen = true;
-                }
-            } else if ($xpath{$i} === '"' && $singleQuoteOpen === false) {
-                if ($doubleQuoteOpen === true) {
-                    $doubleQuoteOpen = false;
-                } else {
-                    $doubleQuoteOpen = true;
-                }
-            } else if ($singleQuoteOpen === false && $doubleQuoteOpen === false) {
-                if ($xpath{$i} === '[') {
-                    $bracketOpen++;
-                } else if ($xpath{$i} === ']') {
-                    $bracketOpen--;
-                } else if ($xpath{$i} === '|' && $bracketOpen === 0) {
+            $char = $xpath[$i];
+
+            if ($char === "'" && $inDoubleQuotedString === false) {
+                $inSingleQuotedString = !$inSingleQuotedString;
+            } elseif ($char === '"' && $inSingleQuotedString === false) {
+                $inDoubleQuotedString = !$inDoubleQuotedString;
+            } elseif ($inSingleQuotedString === false && $inDoubleQuotedString === false) {
+                if ($char === '[') {
+                    $openedBrackets++;
+                } elseif ($char === ']') {
+                    $openedBrackets--;
+                } elseif ($char === '|' && $openedBrackets === 0) {
                     $unionParts[] = substr($xpath, $lastUnion, $i - $lastUnion);
                     $lastUnion = $i + 1;
                 }

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -553,8 +553,8 @@ class NodeElementTest extends ElementTest
     public function testFindAllUnion()
     {
         $node = new NodeElement('some_xpath', $this->session);
-        $xpath = "some_tag1 | some_tag2[@foo =\n 'bar|'']\n | some_tag3[foo | bar]";
-        $expected = "some_xpath/some_tag1 | some_xpath/some_tag2[@foo =\n 'bar|''] | some_xpath/some_tag3[foo | bar]";
+        $xpath = "some_tag1 | some_tag2[@foo =\n 'bar|']\n | some_tag3[foo | bar]";
+        $expected = "some_xpath/some_tag1 | some_xpath/some_tag2[@foo =\n 'bar|'] | some_xpath/some_tag3[foo | bar]";
 
         $this->driver
             ->expects($this->exactly(1))

--- a/tests/Selector/Xpath/ManipulatorTest.php
+++ b/tests/Selector/Xpath/ManipulatorTest.php
@@ -56,8 +56,13 @@ class ManipulatorTest extends \PHPUnit_Framework_TestCase
             ),
             'multiline' => array(
                 'some_xpath',
-                "some_tag1 | some_tag2[@foo =\n 'bar|'']\n | some_tag3[foo | bar]",
-                "some_xpath/some_tag1 | some_xpath/some_tag2[@foo =\n 'bar|''] | some_xpath/some_tag3[foo | bar]",
+                "some_tag1 | some_tag2[@foo =\n 'bar|']\n | some_tag3[foo | bar]",
+                "some_xpath/some_tag1 | some_xpath/some_tag2[@foo =\n 'bar|'] | some_xpath/some_tag3[foo | bar]",
+            ),
+            'containing pipe' => array(
+                'some_xpath',
+                "some_tag[(contains(normalize-space(string(.)), 'foo|bar') | other_tag[contains(./@some_attribute, 'foo|bar')])]",
+                "some_xpath/some_tag[(contains(normalize-space(string(.)), 'foo|bar') | other_tag[contains(./@some_attribute, 'foo|bar')])]",
             ),
         );
     }


### PR DESCRIPTION
For issue #702 .

The pipe operator can appear in many places - a regex is too primitive, we need to actually parse the XPath expression.

This also uncovered a bug in the XPath expressions used for testing which contain a double single quote, which would be a broken XPath expression.