### PR TITLE
[Selector/NamedSelector] Fix PHP 7.2 count() errors

### DIFF
--- a/src/Selector/NamedSelector.php
+++ b/src/Selector/NamedSelector.php
@@ -199,11 +199,13 @@ XPATH
      */
     public function translateToXPath($locator)
     {
-        if (2 < count($locator)) {
+        $isArray = is_array($locator);
+
+        if ($isArray && (2 < count($locator))) {
             throw new \InvalidArgumentException('NamedSelector expects array(name, locator) as argument');
         }
 
-        if (2 == count($locator)) {
+        if ($isArray && (2 == count($locator))) {
             $selector = $locator[0];
             $locator = $locator[1];
         } else {


### PR DESCRIPTION
This pull request fixes an error with the `count()` function in upcoming PHP 7.2.

```
$ cd /tmp


$ git clone https://github.com/minkphp/Mink.git
Cloning into 'Mink'...
remote: Counting objects: 8548, done.
remote: Total 8548 (delta 0), reused 0 (delta 0), pack-reused 8548
Receiving objects: 100% (8548/8548), 1.42 MiB | 0 bytes/s, done.
Resolving deltas: 100% (4178/4178), done.
Checking connectivity... done.


$ cd Mink/


$ git log -1
commit 9ea1cebe3dc529ba3861d87c818f045362c40484
Merge: bb28774 acf5fb1
Author: Christophe Coevoet <stof@notk.org>
Date:   Mon Feb 6 10:59:54 2017 +0100

    Merge pull request #705 from aik099/678-lazy-starting-of-sessions-feat
    
    Auto-start session only upon 1st "->visit(...)" method call


$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 2 installs, 0 updates, 0 removals
  - Installing symfony/css-selector (v3.2.8): Loading from cache
  - Installing symfony/phpunit-bridge (v3.2.8): Loading from cache
symfony/phpunit-bridge suggests installing symfony/debug (For tracking deprecated interfaces usages at runtime with DebugClassLoader)
Writing lock file
Generating autoload files


$ php72 --version
PHP 7.2.0-dev (cli) (built: May  6 2017 07:56:52) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.2.0-dev, Copyright (c) 1998-2017 Zend Technologies


$ php72 /usr/bin/phpunit
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

...............................................................  63 / 500 ( 12%)
...................................................W........WWW 126 / 500 ( 25%)
WWWWWWWWWWWW..............E.................................... 189 / 500 ( 37%)
............................................................... 252 / 500 ( 50%)
........................E...................................... 315 / 500 ( 63%)
............................................................... 378 / 500 ( 75%)
............................................................... 441 / 500 ( 88%)
................WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW     500 / 500 (100%)

Time: 2.86 seconds, Memory: 8.00MB

There were 2 errors:

1) Behat\Mink\Tests\Selector\ExactNamedSelectorTest::testRegisterXpath
count(): Parameter must be an array or an object that implements Countable

/tmp/Mink/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:73
/tmp/Mink/src/Selector/NamedSelector.php:202
/tmp/Mink/tests/Selector/NamedSelectorTest.php:15

2) Behat\Mink\Tests\Selector\PartialNamedSelectorTest::testRegisterXpath
count(): Parameter must be an array or an object that implements Countable

/tmp/Mink/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:73
/tmp/Mink/src/Selector/NamedSelector.php:202
/tmp/Mink/tests/Selector/NamedSelectorTest.php:15

--

There were 59 warnings:

[ ... pruned ... ]

ERRORS!
Tests: 500, Assertions: 885, Errors: 2, Warnings: 59.

Legacy deprecation notices (128)
```