### PR TITLE
Use strpos instead of preg_match for responseContains/ResponseNotContains in WebAssert

### DIFF
--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -321,7 +321,7 @@ class WebAssert
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" was not found anywhere in the HTML response of the current page.', $text);
 
-        $this->assert(strpos($actual, $text) !== FALSE, $message);
+        $this->assert(strpos($actual, $text) !== false, $message);
     }
 
     /**
@@ -336,7 +336,7 @@ class WebAssert
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" appears in the HTML response of this page, but it should not.', $text);
 
-        $this->assert(strpos($actual, $text) === FALSE, $message);
+        $this->assert(strpos($actual, $text) === false, $message);
     }
 
     /**

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -319,10 +319,9 @@ class WebAssert
     public function responseContains($text)
     {
         $actual = $this->session->getPage()->getContent();
-        $regex = '/'.preg_quote($text, '/').'/ui';
         $message = sprintf('The string "%s" was not found anywhere in the HTML response of the current page.', $text);
-
-        $this->assert((bool) preg_match($regex, $actual), $message);
+ 
+        $this->assert(strpos($actual, $text) !== FALSE, $message);
     }
 
     /**
@@ -335,10 +334,9 @@ class WebAssert
     public function responseNotContains($text)
     {
         $actual = $this->session->getPage()->getContent();
-        $regex = '/'.preg_quote($text, '/').'/ui';
         $message = sprintf('The string "%s" appears in the HTML response of this page, but it should not.', $text);
-
-        $this->assert(!preg_match($regex, $actual), $message);
+ 
+        $this->assert(strpos($actual, $text) === FALSE, $message);
     }
 
     /**

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -321,7 +321,7 @@ class WebAssert
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" was not found anywhere in the HTML response of the current page.', $text);
 
-        $this->assert(strpos($actual, $text) !== false, $message);
+        $this->assert(stripos($actual, $text) !== false, $message);
     }
 
     /**
@@ -336,7 +336,7 @@ class WebAssert
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" appears in the HTML response of this page, but it should not.', $text);
 
-        $this->assert(strpos($actual, $text) === false, $message);
+        $this->assert(stripos($actual, $text) === false, $message);
     }
 
     /**

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -320,7 +320,7 @@ class WebAssert
     {
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" was not found anywhere in the HTML response of the current page.', $text);
- 
+
         $this->assert(strpos($actual, $text) !== FALSE, $message);
     }
 
@@ -335,7 +335,7 @@ class WebAssert
     {
         $actual = $this->session->getPage()->getContent();
         $message = sprintf('The string "%s" appears in the HTML response of this page, but it should not.', $text);
- 
+
         $this->assert(strpos($actual, $text) === FALSE, $message);
     }
 


### PR DESCRIPTION
As far as I can tell, especially with the existence of WebAssert::responseMatches, it doesn't make sense to create a regex/use preg_match in responseContains/NotContains. 

Maybe there is a reason for the use of preg_match there, but I did a search for prior issues/history and couldn't find any discussion.  If there was and I missed it, a link would be great.,