### PR TITLE
Add compatibility with PHPUnit 6

### DIFF
--- a/tests/Driver/CoreDriverTest.php
+++ b/tests/Driver/CoreDriverTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Driver;
 
 use Behat\Mink\Element\NodeElement;
+use PHPUnit\Framework\TestCase;
 
-class CoreDriverTest extends \PHPUnit_Framework_TestCase
+class CoreDriverTest extends TestCase
 {
     public function testNoExtraMethods()
     {
@@ -65,7 +66,13 @@ class CoreDriverTest extends \PHPUnit_Framework_TestCase
 
         $driver = $this->getMockForAbstractClass('Behat\Mink\Driver\CoreDriver');
 
-        $this->setExpectedException('Behat\Mink\Exception\UnsupportedDriverActionException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\UnsupportedDriverActionException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\UnsupportedDriverActionException');
+        }
+
         call_user_func_array(array($driver, $method->getName()), $this->getArguments($method));
     }
 

--- a/tests/Element/DocumentElementTest.php
+++ b/tests/Element/DocumentElementTest.php
@@ -273,7 +273,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->clickLink('some link');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->clickLink('some link');
     }
 
@@ -293,7 +300,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->pressButton('some button');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->pressButton('some button');
     }
 
@@ -314,7 +328,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->fillField('some field', 'some val');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->fillField('some field', 'some val');
     }
 
@@ -334,7 +355,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->checkField('some field');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->checkField('some field');
     }
 
@@ -354,7 +382,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->uncheckField('some field');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->uncheckField('some field');
     }
 
@@ -375,7 +410,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->selectFieldOption('some field', 'option2');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->selectFieldOption('some field', 'option2');
     }
 
@@ -396,7 +438,14 @@ class DocumentElementTest extends ElementTest
         );
 
         $this->document->attachFileToField('some field', '/path/to/file');
-        $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('Behat\Mink\Exception\ElementNotFoundException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('Behat\Mink\Exception\ElementNotFoundException');
+        }
+
         $this->document->attachFileToField('some field', '/path/to/file');
     }
 

--- a/tests/Element/ElementTest.php
+++ b/tests/Element/ElementTest.php
@@ -5,8 +5,9 @@ namespace Behat\Mink\Tests\Element;
 use Behat\Mink\Driver\DriverInterface;
 use Behat\Mink\Session;
 use Behat\Mink\Selector\SelectorsHandler;
+use PHPUnit\Framework\TestCase;
 
-abstract class ElementTest extends \PHPUnit_Framework_TestCase
+abstract class ElementTest extends TestCase
 {
     /**
      * Session.

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -489,7 +489,7 @@ class NodeElementTest extends ElementTest
     {
         $node = new NodeElement('some_tag1', $this->session);
 
-        $target = $this->getMock('Behat\Mink\Element\ElementInterface');
+        $target = $this->getMockBuilder('Behat\Mink\Element\ElementInterface')->getMock();
         $target->expects($this->any())
             ->method('getXPath')
             ->will($this->returnValue('some_tag2'));

--- a/tests/Exception/ElementExceptionTest.php
+++ b/tests/Exception/ElementExceptionTest.php
@@ -3,11 +3,12 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ElementException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group legacy
  */
-class ElementExceptionTest extends \PHPUnit_Framework_TestCase
+class ElementExceptionTest extends TestCase
 {
     public function testMessage()
     {

--- a/tests/Exception/ElementHtmlExceptionTest.php
+++ b/tests/Exception/ElementHtmlExceptionTest.php
@@ -3,12 +3,13 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ElementHtmlException;
+use PHPUnit\Framework\TestCase;
 
-class ElementHtmlExceptionTest extends \PHPUnit_Framework_TestCase
+class ElementHtmlExceptionTest extends TestCase
 {
     public function testExceptionToString()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
         $element = $this->getElementMock();
 
         $driver->expects($this->any())

--- a/tests/Exception/ElementNotFoundExceptionTest.php
+++ b/tests/Exception/ElementNotFoundExceptionTest.php
@@ -3,15 +3,16 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ElementNotFoundException;
+use PHPUnit\Framework\TestCase;
 
-class ElementNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ElementNotFoundExceptionTest extends TestCase
 {
     /**
      * @dataProvider provideExceptionMessage
      */
     public function testBuildMessage($message, $type, $selector = null, $locator = null)
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
 
         $exception = new ElementNotFoundException($driver, $type, $selector, $locator);
 
@@ -35,7 +36,7 @@ class ElementNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructWithSession()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
         $session = $this->getMockBuilder('Behat\Mink\Session')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Exception/ElementTextExceptionTest.php
+++ b/tests/Exception/ElementTextExceptionTest.php
@@ -3,12 +3,13 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ElementTextException;
+use PHPUnit\Framework\TestCase;
 
-class ElementTextExceptionTest extends \PHPUnit_Framework_TestCase
+class ElementTextExceptionTest extends TestCase
 {
     public function testExceptionToString()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
         $element = $this->getElementMock();
 
         $driver->expects($this->any())

--- a/tests/Exception/ExpectationExceptionTest.php
+++ b/tests/Exception/ExpectationExceptionTest.php
@@ -3,19 +3,20 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ExpectationException;
+use PHPUnit\Framework\TestCase;
 
-class ExpectationExceptionTest extends \PHPUnit_Framework_TestCase
+class ExpectationExceptionTest extends TestCase
 {
     public function testEmptyMessageAndPreviousException()
     {
-        $exception = new ExpectationException('', $this->getMock('Behat\Mink\Driver\DriverInterface'), new \Exception('Something failed'));
+        $exception = new ExpectationException('', $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock(), new \Exception('Something failed'));
 
         $this->assertEquals('Something failed', $exception->getMessage());
     }
 
     public function testExceptionToString()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getStatusCode')
@@ -50,7 +51,7 @@ TXT;
 
     public function testBigContent()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getStatusCode')
@@ -84,7 +85,7 @@ TXT;
 
     public function testExceptionWhileRenderingString()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
         $driver->expects($this->any())
             ->method('getContent')
             ->will($this->throwException(new \Exception('Broken page')));
@@ -99,7 +100,7 @@ TXT;
      */
     public function testConstructWithSession()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
         $session = $this->getMockBuilder('Behat\Mink\Session')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Exception/ResponseTextExceptionTest.php
+++ b/tests/Exception/ResponseTextExceptionTest.php
@@ -3,12 +3,13 @@
 namespace Behat\Mink\Tests\Exception;
 
 use Behat\Mink\Exception\ResponseTextException;
+use PHPUnit\Framework\TestCase;
 
-class ResponseTextExceptionTest extends \PHPUnit_Framework_TestCase
+class ResponseTextExceptionTest extends TestCase
 {
     public function testExceptionToString()
     {
-        $driver = $this->getMock('Behat\Mink\Driver\DriverInterface');
+        $driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
 
         $driver->expects($this->any())
             ->method('getStatusCode')

--- a/tests/MinkTest.php
+++ b/tests/MinkTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests;
 
 use Behat\Mink\Mink;
+use PHPUnit\Framework\TestCase;
 
-class MinkTest extends \PHPUnit_Framework_TestCase
+class MinkTest extends TestCase
 {
     /**
      * @var Mink
@@ -70,7 +71,12 @@ class MinkTest extends \PHPUnit_Framework_TestCase
         $this->mink->registerSession('mock_session', $session);
         $this->assertSame($session, $this->mink->getSession('mock_session'));
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
 
         $this->mink->getSession('not_registered');
     }
@@ -85,7 +91,12 @@ class MinkTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('session_name', $this->mink->getDefaultSessionName());
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
 
         $this->mink->setDefaultSessionName('not_registered');
     }
@@ -116,7 +127,12 @@ class MinkTest extends \PHPUnit_Framework_TestCase
 
         $this->mink->registerSession('session_1', $session1);
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
 
         $this->mink->getSession();
     }
@@ -148,7 +164,12 @@ class MinkTest extends \PHPUnit_Framework_TestCase
         $this->mink->registerSession('started', $session_2);
         $this->assertTrue($this->mink->isSessionStarted('started'));
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
 
         $this->mink->getSession('not_registered');
     }

--- a/tests/Selector/CssSelectorTest.php
+++ b/tests/Selector/CssSelectorTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Selector;
 
 use Behat\Mink\Selector\CssSelector;
+use PHPUnit\Framework\TestCase;
 
-class CssSelectorTest extends \PHPUnit_Framework_TestCase
+class CssSelectorTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Selector/NamedSelectorTest.php
+++ b/tests/Selector/NamedSelectorTest.php
@@ -4,8 +4,9 @@ namespace Behat\Mink\Tests\Selector;
 
 use Behat\Mink\Selector\NamedSelector;
 use Behat\Mink\Selector\Xpath\Escaper;
+use PHPUnit\Framework\TestCase;
 
-abstract class NamedSelectorTest extends \PHPUnit_Framework_TestCase
+abstract class NamedSelectorTest extends TestCase
 {
     public function testRegisterXpath()
     {
@@ -14,7 +15,12 @@ abstract class NamedSelectorTest extends \PHPUnit_Framework_TestCase
         $selector->registerNamedXpath('some', 'my_xpath');
         $this->assertEquals('my_xpath', $selector->translateToXPath('some'));
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
 
         $selector->translateToXPath('custom');
     }

--- a/tests/Selector/SelectorsHandlerTest.php
+++ b/tests/Selector/SelectorsHandlerTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Selector;
 
 use Behat\Mink\Selector\SelectorsHandler;
+use PHPUnit\Framework\TestCase;
 
-class SelectorsHandlerTest extends \PHPUnit_Framework_TestCase
+class SelectorsHandlerTest extends TestCase
 {
     public function testRegisterSelector()
     {
@@ -67,7 +68,13 @@ class SelectorsHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($ret, $handler->selectorToXpath('custom_selector', $locator));
 
-        $this->setExpectedException('InvalidArgumentException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('InvalidArgumentException');
+        } else {
+            // BC with PHPUnit 4 used for PHP 5.5 and older
+            $this->setExpectedException('InvalidArgumentException');
+        }
+
         $handler->selectorToXpath('undefined', 'asd');
     }
 

--- a/tests/Selector/Xpath/EscaperTest.php
+++ b/tests/Selector/Xpath/EscaperTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Selector\Xpath;
 
 use Behat\Mink\Selector\Xpath\Escaper;
+use PHPUnit\Framework\TestCase;
 
-class EscaperTest extends \PHPUnit_Framework_TestCase
+class EscaperTest extends TestCase
 {
     /**
      * @dataProvider getXpathLiterals

--- a/tests/Selector/Xpath/ManipulatorTest.php
+++ b/tests/Selector/Xpath/ManipulatorTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Selector\Xpath;
 
 use Behat\Mink\Selector\Xpath\Manipulator;
+use PHPUnit\Framework\TestCase;
 
-class ManipulatorTest extends \PHPUnit_Framework_TestCase
+class ManipulatorTest extends TestCase
 {
     /**
      * @dataProvider getPrependedXpath

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests;
 
 use Behat\Mink\Session;
+use PHPUnit\Framework\TestCase;
 
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/WebAssertTest.php
+++ b/tests/WebAssertTest.php
@@ -4,8 +4,9 @@ namespace Behat\Mink\Tests;
 
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\WebAssert;
+use PHPUnit\Framework\TestCase;
 
-class WebAssertTest extends \PHPUnit_Framework_TestCase
+class WebAssertTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -23,7 +24,7 @@ class WebAssertTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $this->session->expects($this->any())
             ->method('getDriver')
-            ->will($this->returnValue($this->getMock('Behat\Mink\Driver\DriverInterface')));
+            ->will($this->returnValue($this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock()));
 
         $this->assert = new WebAssert($this->session);
     }


### PR DESCRIPTION
PHPUnit 6 is the only PHP version supporting PHP 7.2 (and the only current version still maintained after February 3rd when PHPUnit 7 will be released). This makes the testsuite compatible with it.
I kept compat with PHPUnit 4 and 5 (PHPUnit 4.8.35+ only) to keep testing on PHP 5.5 and older (I want to make a release supporting them before bumping to PHP 7.1+)