### PR TITLE
Add support for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 sudo: false
 
-php: [5.4, 5.5, 5.6, 7.0, 7.1, hhvm]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2]
 
 matrix:
   fast_finish: true
@@ -11,7 +11,7 @@ matrix:
       dist: precise
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.1
+    - php: 7.2
       env: DEPENDENCIES=dev
 
 cache:

--- a/src/Selector/NamedSelector.php
+++ b/src/Selector/NamedSelector.php
@@ -199,11 +199,11 @@ XPATH
      */
     public function translateToXPath($locator)
     {
-        if (2 < count($locator)) {
-            throw new \InvalidArgumentException('NamedSelector expects array(name, locator) as argument');
-        }
+        if (\is_array($locator)) {
+            if (2 !== \count($locator)) {
+                throw new \InvalidArgumentException('NamedSelector expects array(name, locator) as argument');
+            }
 
-        if (2 == count($locator)) {
             $selector = $locator[0];
             $locator = $locator[1];
         } else {


### PR DESCRIPTION
This also drops CI for HHVM due to https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html. Spending time on fixing HHVM issues is not worth it anymore (thus, Travis does not give us access to the latest HHVM)