### PR TITLE
Add setAutocompleteValue method

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -180,6 +180,14 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
+    public function setAutocompleteValue($xpath, $value)
+    {
+        throw new UnsupportedDriverActionException('Setting the field value is not supported by %s', $this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function check($xpath)
     {
         throw new UnsupportedDriverActionException('Checking a checkbox is not supported by %s', $this);

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -366,6 +366,19 @@ interface DriverInterface
     public function setValue($xpath, $value);
 
     /**
+     * Sets autocomplete element's value by it's XPath query.
+     *
+     * @param string            $xpath
+     * @param string|bool|array $value
+     *
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     * @throws DriverException                  When the operation cannot be done
+     *
+     * @see \Behat\Mink\Element\NodeElement::setAutocompleteValue
+     */
+    public function setAutocompleteValue($xpath, $value);
+
+    /**
      * Checks checkbox by it's XPath query.
      *
      * @param string $xpath


### PR DESCRIPTION
Added method in order to solve setting a value on autocomplete input elements as commented in [286](https://github.com/minkphp/MinkSelenium2Driver/pull/286), [292](https://github.com/minkphp/MinkSelenium2Driver/issues/292) and  [301](https://github.com/minkphp/MinkSelenium2Driver/issues/301)

