### PR TITLE
Move hasContent method from DocumentElement class to TraversableElement.

### DIFF
--- a/src/Element/DocumentElement.php
+++ b/src/Element/DocumentElement.php
@@ -36,16 +36,4 @@ class DocumentElement extends TraversableElement
     {
         return trim($this->getDriver()->getContent());
     }
-
-    /**
-     * Check whether document has specified content.
-     *
-     * @param string $content
-     *
-     * @return Boolean
-     */
-    public function hasContent($content)
-    {
-        return $this->has('named', array('content', $content));
-    }
 }

--- a/src/Element/TraversableElement.php
+++ b/src/Element/TraversableElement.php
@@ -294,4 +294,16 @@ abstract class TraversableElement extends Element
 
         $field->attachFile($path);
     }
+
+    /**
+     * Check whether element has specified content.
+     *
+     * @param string $content
+     *
+     * @return Boolean
+     */
+    public function hasContent($content)
+    {
+        return $this->has('named', array('content', $content));
+    }
 }


### PR DESCRIPTION
It's useful to find content in DOM elements, not just in the whole document.