### PR TITLE
added pressKey, deprecated keyPress/keyDown/keyUp

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -420,6 +420,14 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
+    public function pressKey($xpath, $char, $modifier = null)
+    {
+        throw new UnsupportedDriverActionException('Keyboard manipulations are not supported by %s', $this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function dragTo($sourceXpath, $destinationXpath)
     {
         throw new UnsupportedDriverActionException('Mouse manipulations are not supported by %s', $this);

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -525,6 +525,8 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyPress($xpath, $char, $modifier = null);
 
@@ -537,6 +539,8 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyDown($xpath, $char, $modifier = null);
 
@@ -549,8 +553,22 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyUp($xpath, $char, $modifier = null);
+
+    /**
+     * Send a sequence of key strokes to the active element
+     *
+     * @param string     $xpath
+     * @param string|int $char     could be either char ('b') or char-code (98)
+     * @param string     $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     * @throws DriverException                  When the operation cannot be done
+     */
+    public function pressKey($xpath, $char, $modifier = null);
 
     /**
      * Drag one element onto another.

--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -310,6 +310,8 @@ class NodeElement extends TraversableElement
      *
      * @param string|int $char     could be either char ('b') or char-code (98)
      * @param string     $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyPress($char, $modifier = null)
     {
@@ -321,6 +323,8 @@ class NodeElement extends TraversableElement
      *
      * @param string|int $char     could be either char ('b') or char-code (98)
      * @param string     $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyDown($char, $modifier = null)
     {
@@ -332,10 +336,23 @@ class NodeElement extends TraversableElement
      *
      * @param string|int $char     could be either char ('b') or char-code (98)
      * @param string     $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @deprecated Deprecating in favor of `pressKey` which is WebDriver (W3C) compliant
      */
     public function keyUp($char, $modifier = null)
     {
         $this->getDriver()->keyUp($this->getXpath(), $char, $modifier);
+    }
+
+    /**
+     * Send a sequence of key strokes to the active element
+     *
+     * @param string|int $char     could be either char ('b') or char-code (98)
+     * @param string     $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     */
+    public function pressKey($char, $modifier = null)
+    {
+        $this->getDriver()->pressKey($this->getXpath(), $char, $modifier);
     }
 
     /**

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -538,6 +538,18 @@ class NodeElementTest extends ElementTest
         $node->keyUp('key');
     }
 
+    public function testPressKey()
+    {
+        $node = new NodeElement('elem', $this->session);
+
+        $this->driver
+            ->expects($this->once())
+            ->method('pressKey')
+            ->with('elem', 'key');
+
+        $node->pressKey('key');
+    }
+
     public function testSubmitForm()
     {
         $node = new NodeElement('some_xpath', $this->session);


### PR DESCRIPTION
Ref.:  https://github.com/minkphp/MinkSelenium2Driver/pull/304#discussion_r246046293

> that's not the same API than previously. After calling keyDown, your implementation already released the key.
>
> I think we should rather add a new pressKey method in Mink, and deprecate these 3 methods. And the new version of the driver would then implement only pressKey.
>
> And we should implement the new method in 1.x too
The old implementation was not good anyway, as it was not actually pressing the key, but only triggering the JS actions (so the default behavior of pressing a key would not happen).