### PR TITLE
Rename boolean type in lowercase

### DIFF
--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -53,7 +53,7 @@ interface DriverInterface
     /**
      * Checks whether driver is started.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isStarted();
 
@@ -142,7 +142,7 @@ interface DriverInterface
     /**
      * Sets HTTP Basic authentication parameters.
      *
-     * @param string|Boolean $user     user name or false to disable authentication
+     * @param string|boolean $user     user name or false to disable authentication
      * @param string         $password password
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
@@ -394,7 +394,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return Boolean
+     * @return boolean
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -408,7 +408,7 @@ interface DriverInterface
      *
      * @param string  $xpath
      * @param string  $value
-     * @param Boolean $multiple
+     * @param boolean $multiple
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -422,7 +422,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return Boolean
+     * @return boolean
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -479,7 +479,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return Boolean
+     * @return boolean
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done

--- a/src/Element/DocumentElement.php
+++ b/src/Element/DocumentElement.php
@@ -42,7 +42,7 @@ class DocumentElement extends TraversableElement
      *
      * @param string $content
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasContent($content)
     {

--- a/src/Element/ElementInterface.php
+++ b/src/Element/ElementInterface.php
@@ -41,7 +41,7 @@ interface ElementInterface
      * @param string       $selector selector engine name
      * @param string|array $locator  selector locator
      *
-     * @return Boolean
+     * @return boolean
      *
      * @see ElementInterface::findAll for the supported selectors
      */

--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -110,7 +110,7 @@ class NodeElement extends TraversableElement
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasAttribute($name)
     {
@@ -198,11 +198,11 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on any other elements is not allowed.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isChecked()
     {
-        return (Boolean) $this->getDriver()->isChecked($this->getXpath());
+        return (boolean) $this->getDriver()->isChecked($this->getXpath());
     }
 
     /**
@@ -216,7 +216,7 @@ class NodeElement extends TraversableElement
      * Calling this method on any other elements is not allowed.
      *
      * @param string  $option
-     * @param Boolean $multiple whether the option should be added to the selection for multiple selects
+     * @param boolean $multiple whether the option should be added to the selection for multiple selects
      *
      * @throws ElementNotFoundException when the option is not found in the select box
      */
@@ -242,11 +242,11 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on any other elements is not allowed.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isSelected()
     {
-        return (Boolean) $this->getDriver()->isSelected($this->getXpath());
+        return (boolean) $this->getDriver()->isSelected($this->getXpath());
     }
 
     /**
@@ -264,11 +264,11 @@ class NodeElement extends TraversableElement
     /**
      * Checks whether current node is visible on page.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isVisible()
     {
-        return (Boolean) $this->getDriver()->isVisible($this->getXpath());
+        return (boolean) $this->getDriver()->isVisible($this->getXpath());
     }
 
     /**

--- a/src/Element/TraversableElement.php
+++ b/src/Element/TraversableElement.php
@@ -36,7 +36,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator link id, title, text or image alt
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasLink($locator)
     {
@@ -78,7 +78,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator button id, value or alt
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasButton($locator)
     {
@@ -120,7 +120,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasField($locator)
     {
@@ -165,7 +165,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return Boolean
+     * @return boolean
      *
      * @see NodeElement::isChecked
      */
@@ -181,7 +181,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return Boolean
+     * @return boolean
      *
      * @see NodeElement::isChecked
      */
@@ -233,7 +233,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator select id, name or label
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasSelect($locator)
     {
@@ -245,7 +245,7 @@ abstract class TraversableElement extends Element
      *
      * @param string  $locator  input id, name or label
      * @param string  $value    option value
-     * @param Boolean $multiple select multiple options
+     * @param boolean $multiple select multiple options
      *
      * @throws ElementNotFoundException
      *
@@ -267,7 +267,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator table id or caption
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasTable($locator)
     {

--- a/src/Mink.php
+++ b/src/Mink.php
@@ -64,7 +64,7 @@ class Mink
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasSession($name)
     {

--- a/src/Selector/SelectorsHandler.php
+++ b/src/Selector/SelectorsHandler.php
@@ -56,7 +56,7 @@ class SelectorsHandler
      *
      * @param string $name selector engine name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isSelectorRegistered($name)
     {

--- a/src/Session.php
+++ b/src/Session.php
@@ -47,7 +47,7 @@ class Session
     /**
      * Checks whether session (driver) was started.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isStarted()
     {
@@ -151,7 +151,7 @@ class Session
     /**
      * Sets HTTP Basic authentication parameters.
      *
-     * @param string|Boolean $user     user name or false to disable authentication
+     * @param string|boolean $user     user name or false to disable authentication
      * @param string         $password password
      */
     public function setBasicAuth($user, $password = '')


### PR DESCRIPTION
vimeo/psalm raise errors from Behat/Mink boolean return type.
As I can see in a [psalm issue](https://github.com/vimeo/psalm/issues/294#issuecomment-344560596), Boolean type must be lowercase
