### PR TITLE
Allow selectors and replacements to be registered late

### DIFF
--- a/src/Selector/NamedSelector.php
+++ b/src/Selector/NamedSelector.php
@@ -169,11 +169,11 @@ XPATH
         $this->xpathEscaper = new Escaper();
 
         foreach ($this->replacements as $from => $to) {
-            $this->replacements[$from] = strtr($to, $this->replacements);
+            $this->registerReplacement($from, $to);
         }
 
         foreach ($this->selectors as $alias => $selector) {
-            $this->selectors[$alias] = strtr($selector, $this->replacements);
+            $this->registerNamedXpath($alias, $selector);
         }
     }
 
@@ -185,7 +185,7 @@ XPATH
      */
     public function registerNamedXpath($name, $xpath)
     {
-        $this->selectors[$name] = $xpath;
+        $this->selectors[$name] = strtr($xpath, $this->replacements);
     }
 
     /**
@@ -229,16 +229,32 @@ XPATH
     }
 
     /**
-     * Registers a replacement in the list of replacements.
+     * Register a string replacement used to reduce duplication and increase readability in a Named XPath selector.
      *
-     * This method must be called in the constructor before calling the parent constructor.
+     * Replacements can make use of other replacements but any consumed replacement must have already been defined
+     * beforehand.
      *
-     * @param string $from
-     * @param string $to
+     * For example you may have the following translations:
+     *
+     *      %idMatch%           => ./@id = %locator%
+     *      %idOrNameMatch%     => (%idMatch% or ./@name = %locator%)
+     *
+     * Because the %idOrNameMatch% replacement consumes the %idMatch% replacement, it must be defined afterwards.
+     *
+     * You may then use this in an a Named XPath:
+     *
+     *     .//fieldset[%idOrNameMatch%]
+     *
+     * And it would be translated to:
+     *
+     *     .//fieldset[(./@id = %locator% or /@name = %locator%)]
+     *
+     * @param string $from The source, typically a string wrapped in % markers
+     * @param string $to The translation
      */
-    protected function registerReplacement($from, $to)
+    public function registerReplacement($from, $to)
     {
-        $this->replacements[$from] = $to;
+        $this->replacements[$from] = strtr($to, $this->replacements);
     }
 
     private function escapeLocator($locator)

--- a/tests/Selector/fixtures/test.html
+++ b/tests/Selector/fixtures/test.html
@@ -266,6 +266,12 @@
             <label>the-field<input type="fiLe"/></label>
         </div>
 
+        <div id="test-for-late-registered-replacements">
+            <input type="text" id="late-registered-input"/>
+            <input type="text" name="late-registered-input"/>
+            <input type="text" id="late-registered-input-with-matching-name" name="late-registered-input-with-matching-name"/>
+        </div>
+
         <div id="test-for-select-related-stuff">
             <!-- match select stuff -->
             <select name="the-select-stuff-test">


### PR DESCRIPTION
This allows projects using Mink to create their Named and Partial
selectors, and then to add additional replacements and selectors to be
registered for subsequent use.

This is particularly useful in projects with a distributed plugin
architecture which make use of replacements and selectors
without abusing Reflection to do so.

This is something that we currently do in Moodle for Behat for exactly this reason:
Our hack with Reflection to access the properties to allow proper translation: https://github.com/andrewnicols/moodle/blob/MDL-66559-master/lib/behat/classes/named_selector.php#L48
Registration of plugin replacements and selectors: https://github.com/andrewnicols/moodle/blob/MDL-66559-master/lib/tests/behat/behat_hooks.php#L743