### PR TITLE
Add null as possible return type for NodeElement::getValue()

### DIFF
--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -84,7 +84,7 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on other elements than form fields or option elements is not allowed.
      *
-     * @return string|bool|array
+     * @return string|bool|array|null
      */
     public function getValue()
     {


### PR DESCRIPTION
If DriverInterface::getValue() can return null, so does this method.