### PR TITLE
Improve the CI setup for PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ cache:
 
 before_install:
   - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
+  # Install symfony/error-handler on compatible PHP versions to avoid a deprecation warning of the old DebugClassLoader and ErrorHandler classes
+  - if [[ "$TRAVIS_PHP_VERSION" != 5.* && "$TRAVIS_PHP_VERSION" != 7.0 ]]; then composer require --no-update --dev symfony/error-handler "^4.4 || ^5.0"; fi;
 
 install:
   - composer update $COMPOSER_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,25 +16,23 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
     - php: 7.2
-      env: DEPENDENCIES=dev SYMFONY_PHPUNIT_VERSION=7.5
+      env: DEPENDENCIES=dev
     - php: 7.3
-      env: DEPENDENCIES=dev SYMFONY_PHPUNIT_VERSION=7.5
+      env: DEPENDENCIES=dev
     - php: 7.4
-      env: DEPENDENCIES=dev SYMFONY_PHPUNIT_VERSION=7.5
+      env: DEPENDENCIES=dev
 
 cache:
   directories:
     - $HOME/.composer/cache/files
-    - $HOME/symfony-bridge/.phpunit
 
 before_install:
   - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
 
 install:
   - composer update $COMPOSER_FLAGS
-  - vendor/bin/simple-phpunit install
 
-script: vendor/bin/simple-phpunit -v --coverage-clover=coverage.clover
+script: vendor/bin/phpunit -v --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
     },
 
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.2"
+        "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20"
+
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
 
     "require-dev": {
+        "symfony/debug": "^2.7|^3.0|^4.0",
         "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5",
         "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20"
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,4 +12,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>


### PR DESCRIPTION
- Install PHPUnit through composer to control the version being used more easily
- Add the Symfony debug component to report all deprecations