### PR TITLE
Fix deps - require symfony/css-selector v4.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 
     "require": {
         "php":                   ">=5.3.1",
-        "symfony/css-selector":  "^2.7|^3.0|^4.0|^5.0"
+        "symfony/css-selector":  "^4.4|^5.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
after a lot of trial and errors to find the CI issue in https://github.com/atk4/ui/pull/1493 when using `composer update --prefer-lowest` I found out:

- at least symfony/css-selector v4.0+ is required
- even with latest v3.4 like v3.4.44 did not fixed

because 4.4 is the only supported version of v4, requiring v4.4,