### PR TITLE
Add support for executeScript/evaluateScript args

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -428,7 +428,7 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function executeScript($script)
+    public function executeScript($script, array $args = [])
     {
         throw new UnsupportedDriverActionException('JS is not supported by %s', $this);
     }
@@ -436,7 +436,7 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function evaluateScript($script)
+    public function evaluateScript($script, array $args = [])
     {
         throw new UnsupportedDriverActionException('JS is not supported by %s', $this);
     }
@@ -444,7 +444,7 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
-    public function wait($timeout, $condition)
+    public function wait($timeout, $condition, array $args = [])
     {
         throw new UnsupportedDriverActionException('JS is not supported by %s', $this);
     }

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -569,11 +569,12 @@ interface DriverInterface
      * Executes JS script.
      *
      * @param string $script
+     * @param array  $args
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    public function executeScript($script);
+    public function executeScript($script, array $args = []);
 
     /**
      * Evaluates JS script.
@@ -582,26 +583,28 @@ interface DriverInterface
      * must accept the expression both with and without the keyword.
      *
      * @param string $script
+     * @param array  $args
      *
      * @return mixed
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    public function evaluateScript($script);
+    public function evaluateScript($script, array $args = []);
 
     /**
      * Waits some time or until JS condition turns true.
      *
      * @param int    $timeout   timeout in milliseconds
      * @param string $condition JS condition
+     * @param array  $args
      *
      * @return bool
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    public function wait($timeout, $condition);
+    public function wait($timeout, $condition, array $args = []);
 
     /**
      * Set the dimensions of the window.

--- a/src/Session.php
+++ b/src/Session.php
@@ -325,22 +325,24 @@ class Session
      * Execute JS in browser.
      *
      * @param string $script javascript
+     * @param array  $args
      */
-    public function executeScript($script)
+    public function executeScript($script, array $args = [])
     {
-        $this->driver->executeScript($script);
+        $this->driver->executeScript($script, $args);
     }
 
     /**
      * Execute JS in browser and return its response.
      *
      * @param string $script javascript
+     * @param array  $args
      *
      * @return mixed
      */
-    public function evaluateScript($script)
+    public function evaluateScript($script, array $args = [])
     {
-        return $this->driver->evaluateScript($script);
+        return $this->driver->evaluateScript($script, $args);
     }
 
     /**
@@ -348,12 +350,13 @@ class Session
      *
      * @param int    $time      time in milliseconds
      * @param string $condition JS condition
+     * @param array  $args
      *
      * @return bool
      */
-    public function wait($time, $condition = 'false')
+    public function wait($time, $condition = 'false', array $args = [])
     {
-        return $this->driver->wait($time, $condition);
+        return $this->driver->wait($time, $condition, $args);
     }
 
     /**


### PR DESCRIPTION
The args support is necessary as webdriver objects must be passed natively to the underlaying drivers & cannot be serialized directly into the 1st script argument.

Example `executeScript` method prototype of one of the most popular driver - https://github.com/php-webdriver/php-webdriver/blob/8ffa927b270e932449e8015abf4d38bb0eff24b7/lib/Remote/RemoteWebDriver.php#L324