### PR TITLE
Deprecate keyPress, keyDown, keyUp in favor of pressKey.

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -396,8 +396,17 @@ abstract class CoreDriver implements DriverInterface
     /**
      * {@inheritdoc}
      */
+    public function pressKey($xpath, $keys)
+    {
+        throw new UnsupportedDriverActionException('Keyboard manipulations are not supported by %s', $this);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function keyPress($xpath, $char, $modifier = null)
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.11 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
         throw new UnsupportedDriverActionException('Keyboard manipulations are not supported by %s', $this);
     }
 
@@ -406,6 +415,7 @@ abstract class CoreDriver implements DriverInterface
      */
     public function keyDown($xpath, $char, $modifier = null)
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.11 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
         throw new UnsupportedDriverActionException('Keyboard manipulations are not supported by %s', $this);
     }
 
@@ -414,6 +424,7 @@ abstract class CoreDriver implements DriverInterface
      */
     public function keyUp($xpath, $char, $modifier = null)
     {
+        @trigger_error(sprintf('The method %s is deprecated as of 1.11 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
         throw new UnsupportedDriverActionException('Keyboard manipulations are not supported by %s', $this);
     }
 

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -519,6 +519,15 @@ interface DriverInterface
     public function blur($xpath);
 
     /**
+     * @param string           $xpath
+     * @param string|array|int $keys  a string to type ('PHP Hypertext Preprocessor'), a integer key code (88), or an array of keys to press in sequence (e.g.: ["\u{E008}", 'H', "\u{E001}", 'ello']). See https://w3c.github.io/webdriver/#keyboard-actions
+     *
+     * @throws UnsupportedDriverActionException When operation not supported by the driver
+     * @throws DriverException                  When the operation cannot be done
+     */
+    public function pressKey($xpath, $keys);
+
+    /**
      * Presses specific keyboard key.
      *
      * @param string     $xpath
@@ -527,6 +536,8 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated use pressKey($xpath, $keys) instead.
      */
     public function keyPress($xpath, $char, $modifier = null);
 
@@ -539,6 +550,8 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated use pressKey($xpath, $keys) instead.
      */
     public function keyDown($xpath, $char, $modifier = null);
 
@@ -551,6 +564,8 @@ interface DriverInterface
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
+     *
+     * @deprecated use pressKey($xpath, $keys) instead.
      */
     public function keyUp($xpath, $char, $modifier = null);
 

--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -306,25 +306,38 @@ class NodeElement extends TraversableElement
     }
 
     /**
+     * Press one or more keyboard keys on an element.
+     *
+     * @param string|int|array $keys a string to type ('PHP Hypertext Preprocessor'), a integer key code (88), or an array of keys to press in sequence (e.g.: ["\u{E008}", 'H', "\u{E001}", 'ello']). See https://w3c.github.io/webdriver/#keyboard-actions
+     */
+    public function pressKey($keys) {
+        $this->getDriver()->pressKey($this->getXpath(), $keys);
+    }
+
+    /**
      * Presses specific keyboard key.
      *
      * @param string|int  $char     could be either char ('b') or char-code (98)
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @deprecated use pressKey($keys) instead.
      */
     public function keyPress($char, $modifier = null)
     {
-        $this->getDriver()->keyPress($this->getXpath(), $char, $modifier);
+        $this->pressKey($this->wrapCharWithModifier($char, $modifier));
     }
 
     /**
      * Pressed down specific keyboard key.
      *
      * @param string|int  $char     could be either char ('b') or char-code (98)
-     * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')'
+     *
+     * @deprecated use pressKey($keys) instead.
      */
     public function keyDown($char, $modifier = null)
     {
-        $this->getDriver()->keyDown($this->getXpath(), $char, $modifier);
+        $this->pressKey($this->wrapCharWithModifier($char, $modifier));
     }
 
     /**
@@ -332,10 +345,12 @@ class NodeElement extends TraversableElement
      *
      * @param string|int  $char     could be either char ('b') or char-code (98)
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     *
+     * @deprecated use pressKey($keys) instead.
      */
     public function keyUp($char, $modifier = null)
     {
-        $this->getDriver()->keyUp($this->getXpath(), $char, $modifier);
+        $this->pressKey($this->wrapCharWithModifier($char, $modifier));
     }
 
     /**
@@ -346,5 +361,28 @@ class NodeElement extends TraversableElement
     public function submit()
     {
         $this->getDriver()->submitForm($this->getXpath());
+    }
+
+    /**
+     * Polyfill to convert from deprecated keyPress(), keyDown(), keyUp() parameters to pressKey() parameters.
+     *
+     * @param string|int  $char     could be either char ('b') or char-code (98)
+     * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
+     * @return string|int|array     a $keys parameter that pressKey() can parse
+     */
+    private function wrapCharWithModifier($char, $modifier = null)
+    {
+        switch ($modifier) {
+            case 'ctrl':
+                return ["\u{E009}", $char, "\u{E001}"];
+            case 'alt':
+                return ["\u{E00A}", $char, "\u{E001}"];
+            case 'shift':
+                return ["\u{E008}", $char, "\u{E001}"];
+            case 'meta':
+                return ["\u{E03D}", $char, "\u{E001}"];
+            default:
+                return $char;
+        }
     }
 }

--- a/tests/Driver/CoreDriverTest.php
+++ b/tests/Driver/CoreDriverTest.php
@@ -64,6 +64,10 @@ class CoreDriverTest extends TestCase
         if ('setSession' === $method->getName()) {
             return; // setSession is actually implemented, so we don't expect an exception here.
         }
+        if (in_array($method->getName(), ['keyPress', 'keyDown', 'keyUp'])) {
+            return; // Skip deprecated methods in the driver
+        }
+
 
         $driver = $this->getMockForAbstractClass('Behat\Mink\Driver\CoreDriver');
 

--- a/tests/Element/NodeElementTest.php
+++ b/tests/Element/NodeElementTest.php
@@ -505,7 +505,7 @@ class NodeElementTest extends ElementTest
 
         $this->driver
             ->expects($this->once())
-            ->method('keyPress')
+            ->method('pressKey')
             ->with('elem', 'key');
 
         $node->keyPress('key');
@@ -517,7 +517,7 @@ class NodeElementTest extends ElementTest
 
         $this->driver
             ->expects($this->once())
-            ->method('keyDown')
+            ->method('pressKey')
             ->with('elem', 'key');
 
         $node->keyDown('key');
@@ -529,7 +529,7 @@ class NodeElementTest extends ElementTest
 
         $this->driver
             ->expects($this->once())
-            ->method('keyUp')
+            ->method('pressKey')
             ->with('elem', 'key');
 
         $node->keyUp('key');


### PR DESCRIPTION
## Problem / motivation

in #828, @stof said that "the [driver methods] that should actually be deprecated are the separate keydown, keypress and keyup methods in favor of a single pressKey method to match what is actually possible in browsers."

## Proposed resolution

* Deprecate `DriverInterface::keyDown()`, `DriverInterface::keyPress()`, and `DriverInterface::keyUp()` in favor of a new `DriverInterface::pressKey()`
* Deprecate `NodeElement::keyDown()`, `NodeElement::keyPress()`, and `NodeElement::keyUp()` in favor of a new `NodeElement::pressKey()`

## Notes

I modelled the `DriverInterface::pressKey()` method after [php-webdriver/php-webdriver's `\Facebook\WebDriver\Remote\RemoteKeyboard::sendKeys()`](https://github.com/php-webdriver/php-webdriver/blob/b27ddf458d273c7d4602106fcaf978aa0b7fe15a/lib/Remote/RemoteKeyboard.php#L31-L48)