### PR TITLE
fix: update phpunit config syntax for phpunit 9

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <testsuites>
         <testsuite name="Behat Mink test suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />


### PR DESCRIPTION
There are some deprecated elements in phpunit.xml.dist, resulting in this warning on a clean master checkout:
```
> ./vendor/bin/phpunit                                                                                                                        Mink master
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing
...............................................................  63 / 511 ( 12%)
............................................................... 126 / 511 ( 24%)
............................................................... 189 / 511 ( 36%)
............................................................... 252 / 511 ( 49%)
............................................................... 315 / 511 ( 61%)
............................................................... 378 / 511 ( 73%)
............................................................... 441 / 511 ( 86%)
............................................................... 504 / 511 ( 98%)
.......                                                         511 / 511 (100%)

Time: 00:02.658, Memory: 14.00 MB

OK (511 tests, 910 assertions)

Legacy deprecation notices (128)
```

After applying the suggestion and rearranging the elements to decrease the diff size, it works as expected:
```
> ./vendor/bin/phpunit                                                                                                                Mink phpunit-config
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

Testing
...............................................................  63 / 511 ( 12%)
............................................................... 126 / 511 ( 24%)
............................................................... 189 / 511 ( 36%)
............................................................... 252 / 511 ( 49%)
............................................................... 315 / 511 ( 61%)
............................................................... 378 / 511 ( 73%)
............................................................... 441 / 511 ( 86%)
............................................................... 504 / 511 ( 98%)
.......                                                         511 / 511 (100%)

Time: 00:02.641, Memory: 14.00 MB

OK (511 tests, 910 assertions)

Legacy deprecation notices (128)
```

