### PR TITLE
fix: avoid a TypeError if findAll returns a null

### DIFF
--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -145,7 +145,7 @@ abstract class Element implements ElementInterface
     {
         $items = $this->findAll($selector, $locator);
 
-        return count($items) ? current($items) : null;
+        return is_array($items) && count($items) ? current($items) : null;
     }
 
     /**

--- a/tests/Element/DocumentElementTest.php
+++ b/tests/Element/DocumentElementTest.php
@@ -58,26 +58,28 @@ class DocumentElementTest extends ElementTest
     public function testFind()
     {
         $this->driver
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('find')
             ->with('//html/h3[a]')
-            ->will($this->onConsecutiveCalls(array(2, 3, 4), array(1, 2), array()));
+            ->will($this->onConsecutiveCalls(array(2, 3, 4), array(1, 2), array(), null));
 
         $xpath = 'h3[a]';
         $css = 'h3 > a';
 
         $this->selectors
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('selectorToXpath')
             ->will($this->returnValueMap(array(
                 array('xpath', $xpath, $xpath),
                 array('xpath', $xpath, $xpath),
+                array('css', $css, $xpath),
                 array('css', $css, $xpath),
             )));
 
         $this->assertEquals(2, $this->document->find('xpath', $xpath));
         $this->assertEquals(1, $this->document->find('css', $css));
         $this->assertNull($this->document->find('xpath', $xpath));
+        $this->assertNull($this->document->find('css', $css));
     }
 
     public function testFindField()


### PR DESCRIPTION
On PHP 8.1, when running some internal tests I was getting a TypeError because the driver would return a null for findAll.

This adds an is_array check before calling count, just in case.