### PR TITLE
Improve phpdoc types

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -12,6 +12,7 @@ namespace Behat\Mink\Driver;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Mink\KeyModifier;
 use Behat\Mink\Session;
 
 /**
@@ -28,7 +29,9 @@ abstract class CoreDriver implements DriverInterface
     private $session;
 
     /**
-     * {@inheritdoc}
+     * @return void
+     *
+     * @final since 1.11
      */
     public function setSession(Session $session)
     {
@@ -36,7 +39,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function start()
     {
@@ -44,7 +47,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     public function isStarted()
     {
@@ -52,7 +55,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function stop()
     {
@@ -60,7 +63,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function reset()
     {
@@ -68,7 +71,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $url
+     *
+     * @return void
      */
     public function visit($url)
     {
@@ -76,7 +81,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getCurrentUrl()
     {
@@ -84,7 +89,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getContent()
     {
@@ -92,7 +97,11 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return NodeElement[]
+     *
+     * @final since 1.11
      */
     public function find($xpath)
     {
@@ -122,7 +131,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return string
      */
     public function getTagName($xpath)
     {
@@ -130,7 +141,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return string
      */
     public function getText($xpath)
     {
@@ -138,7 +151,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return string
      */
     public function getHtml($xpath)
     {
@@ -146,7 +161,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return string
      */
     public function getOuterHtml($xpath)
     {
@@ -154,7 +171,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     * @param string $name
+     *
+     * @return string|null
      */
     public function getAttribute($xpath, $name)
     {
@@ -162,7 +182,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return string|bool|array|null
      */
     public function getValue($xpath)
     {
@@ -170,7 +192,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string            $xpath
+     * @param string|bool|array $value
+     *
+     * @return void
      */
     public function setValue($xpath, $value)
     {
@@ -178,7 +203,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function check($xpath)
     {
@@ -186,7 +213,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function uncheck($xpath)
     {
@@ -194,7 +223,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return bool
      */
     public function isChecked($xpath)
     {
@@ -202,7 +233,11 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     * @param string $value
+     * @param bool   $multiple
+     *
+     * @return void
      */
     public function selectOption($xpath, $value, $multiple = false)
     {
@@ -210,7 +245,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function click($xpath)
     {
@@ -218,7 +255,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     * @param string $path
+     *
+     * @return void
      */
     public function attachFile($xpath, $path)
     {
@@ -226,7 +266,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function reload()
     {
@@ -234,7 +274,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function forward()
     {
@@ -242,7 +282,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     public function back()
     {
@@ -250,7 +290,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string|false $user
+     * @param string       $password
+     *
+     * @return void
      */
     public function setBasicAuth($user, $password)
     {
@@ -258,7 +301,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string|null $name
+     *
+     * @return void
      */
     public function switchToWindow($name = null)
     {
@@ -266,7 +311,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string|null $name
+     *
+     * @return void
      */
     public function switchToIFrame($name = null)
     {
@@ -274,7 +321,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     * @param string $value
+     *
+     * @return void
      */
     public function setRequestHeader($name, $value)
     {
@@ -282,7 +332,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return array<string, string|string[]>
      */
     public function getResponseHeaders()
     {
@@ -290,7 +340,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string      $name
+     * @param string|null $value
+     *
+     * @return void
      */
     public function setCookie($name, $value = null)
     {
@@ -298,7 +351,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $name
+     *
+     * @return string|null
      */
     public function getCookie($name)
     {
@@ -306,7 +361,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     public function getStatusCode()
     {
@@ -314,7 +369,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getScreenshot()
     {
@@ -322,7 +377,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string[]
      */
     public function getWindowNames()
     {
@@ -330,7 +385,7 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @return string
      */
     public function getWindowName()
     {
@@ -338,7 +393,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function doubleClick($xpath)
     {
@@ -346,7 +403,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function rightClick($xpath)
     {
@@ -354,7 +413,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return bool
      */
     public function isVisible($xpath)
     {
@@ -362,7 +423,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return bool
      */
     public function isSelected($xpath)
     {
@@ -370,7 +433,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function mouseOver($xpath)
     {
@@ -378,7 +443,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function focus($xpath)
     {
@@ -386,7 +453,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function blur($xpath)
     {
@@ -394,7 +463,13 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string      $xpath
+     * @param string|int  $char
+     * @param string|null $modifier
+     *
+     * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyPress($xpath, $char, $modifier = null)
     {
@@ -402,7 +477,13 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string      $xpath
+     * @param string|int  $char
+     * @param string|null $modifier
+     *
+     * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyDown($xpath, $char, $modifier = null)
     {
@@ -410,7 +491,13 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string      $xpath
+     * @param string|int  $char
+     * @param string|null $modifier
+     *
+     * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyUp($xpath, $char, $modifier = null)
     {
@@ -418,7 +505,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $sourceXpath
+     * @param string $destinationXpath
+     *
+     * @return void
      */
     public function dragTo($sourceXpath, $destinationXpath)
     {
@@ -426,7 +516,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $script
+     *
+     * @return void
      */
     public function executeScript($script)
     {
@@ -434,7 +526,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $script
+     *
+     * @return mixed
      */
     public function evaluateScript($script)
     {
@@ -442,7 +536,10 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int    $timeout
+     * @param string $condition
+     *
+     * @return bool
      */
     public function wait($timeout, $condition)
     {
@@ -450,7 +547,11 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param int         $width
+     * @param int         $height
+     * @param string|null $name
+     *
+     * @return void
      */
     public function resizeWindow($width, $height, $name = null)
     {
@@ -458,7 +559,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string|null $name
+     *
+     * @return void
      */
     public function maximizeWindow($name = null)
     {
@@ -466,7 +569,9 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $xpath
+     *
+     * @return void
      */
     public function submitForm($xpath)
     {

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -27,6 +27,8 @@ interface DriverInterface
      * Sets driver's current session.
      *
      * @param Session $session
+     *
+     * @return void
      */
     public function setSession(Session $session);
 
@@ -47,6 +49,8 @@ interface DriverInterface
      * implementations are free to handle it silently or to fail with an
      * exception.
      *
+     * @return void
+     *
      * @throws DriverException When the driver cannot be started
      */
     public function start();
@@ -54,7 +58,7 @@ interface DriverInterface
     /**
      * Checks whether driver is started.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStarted();
 
@@ -69,6 +73,8 @@ interface DriverInterface
      * Calling stop on a stopped driver is an undefined behavior. Driver
      * implementations are free to handle it silently or to fail with an
      * exception.
+     *
+     * @return void
      *
      * @throws DriverException When the driver cannot be closed
      */
@@ -93,6 +99,8 @@ interface DriverInterface
      * - stop()
      *
      * Calling reset on a stopped driver is an undefined behavior.
+     *
+     * @return void
      */
     public function reset();
 
@@ -100,6 +108,8 @@ interface DriverInterface
      * Visit specified URL.
      *
      * @param string $url url of the page
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -119,6 +129,8 @@ interface DriverInterface
     /**
      * Reloads current page.
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -126,6 +138,8 @@ interface DriverInterface
 
     /**
      * Moves browser forward 1 page.
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -135,6 +149,8 @@ interface DriverInterface
     /**
      * Moves browser backward 1 page.
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -143,8 +159,10 @@ interface DriverInterface
     /**
      * Sets HTTP Basic authentication parameters.
      *
-     * @param string|boolean $user     user name or false to disable authentication
-     * @param string         $password password
+     * @param string|false $user     user name or false to disable authentication
+     * @param string       $password password
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -156,6 +174,8 @@ interface DriverInterface
      *
      * @param string|null $name window name (null for switching back to main window)
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -165,6 +185,8 @@ interface DriverInterface
      * Switches to specific iFrame.
      *
      * @param string|null $name iframe name (null for switching back)
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -176,6 +198,8 @@ interface DriverInterface
      *
      * @param string $name
      * @param string $value
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -199,6 +223,8 @@ interface DriverInterface
      *
      * @param string      $name
      * @param string|null $value
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -361,6 +387,8 @@ interface DriverInterface
      * @param string            $xpath
      * @param string|bool|array $value
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      *
@@ -372,6 +400,8 @@ interface DriverInterface
      * Checks checkbox by its XPath query.
      *
      * @param string $xpath
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -385,6 +415,8 @@ interface DriverInterface
      *
      * @param string $xpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      *
@@ -397,7 +429,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return boolean
+     * @return bool
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -409,9 +441,11 @@ interface DriverInterface
     /**
      * Selects option from select field or value in radio group located by its XPath query.
      *
-     * @param string  $xpath
-     * @param string  $value
-     * @param boolean $multiple
+     * @param string $xpath
+     * @param string $value
+     * @param bool   $multiple
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -425,7 +459,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return boolean
+     * @return bool
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -439,6 +473,8 @@ interface DriverInterface
      *
      * @param string $xpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -448,6 +484,8 @@ interface DriverInterface
      * Double-clicks button or link located by its XPath query.
      *
      * @param string $xpath
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -459,6 +497,8 @@ interface DriverInterface
      *
      * @param string $xpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -469,6 +509,8 @@ interface DriverInterface
      *
      * @param string $xpath
      * @param string $path
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -482,7 +524,7 @@ interface DriverInterface
      *
      * @param string $xpath
      *
-     * @return boolean
+     * @return bool
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -494,6 +536,8 @@ interface DriverInterface
      *
      * @param string $xpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -504,6 +548,8 @@ interface DriverInterface
      *
      * @param string $xpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -513,6 +559,8 @@ interface DriverInterface
      * Removes focus from element.
      *
      * @param string $xpath
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -528,6 +576,8 @@ interface DriverInterface
      *
      * @phpstan-param KeyModifier::*|null $modifier
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -541,6 +591,8 @@ interface DriverInterface
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
      *
      * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -556,6 +608,8 @@ interface DriverInterface
      *
      * @phpstan-param KeyModifier::*|null $modifier
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -567,6 +621,8 @@ interface DriverInterface
      * @param string $sourceXpath
      * @param string $destinationXpath
      *
+     * @return void
+     *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
@@ -576,6 +632,8 @@ interface DriverInterface
      * Executes JS script.
      *
      * @param string $script
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -613,9 +671,11 @@ interface DriverInterface
     /**
      * Set the dimensions of the window.
      *
-     * @param int    $width  set the window width, measured in pixels
-     * @param int    $height set the window height, measured in pixels
-     * @param string $name   window name (null for the main window)
+     * @param int         $width  set the window width, measured in pixels
+     * @param int         $height set the window height, measured in pixels
+     * @param string|null $name   window name (null for the main window)
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -625,7 +685,9 @@ interface DriverInterface
     /**
      * Maximizes the window if it is not maximized already.
      *
-     * @param string $name window name (null for the main window)
+     * @param string|null $name window name (null for the main window)
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
@@ -636,6 +698,8 @@ interface DriverInterface
      * Submits the form.
      *
      * @param string $xpath Xpath.
+     *
+     * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done

--- a/src/Element/DocumentElement.php
+++ b/src/Element/DocumentElement.php
@@ -42,7 +42,7 @@ class DocumentElement extends TraversableElement
      *
      * @param string $content
      *
-     * @return boolean
+     * @return bool
      */
     public function hasContent($content)
     {

--- a/src/Element/ElementInterface.php
+++ b/src/Element/ElementInterface.php
@@ -41,7 +41,7 @@ interface ElementInterface
      * @param string       $selector selector engine name
      * @param string|array $locator  selector locator
      *
-     * @return boolean
+     * @return bool
      *
      * @see ElementInterface::findAll for the supported selectors
      */

--- a/src/Element/NodeElement.php
+++ b/src/Element/NodeElement.php
@@ -21,6 +21,9 @@ use Behat\Mink\Exception\ElementNotFoundException;
  */
 class NodeElement extends TraversableElement
 {
+    /**
+     * @var string
+     */
     private $xpath;
 
     /**
@@ -99,6 +102,8 @@ class NodeElement extends TraversableElement
      *
      * @param string|bool|array $value
      *
+     * @return void
+     *
      * @see NodeElement::getValue for the format of the value for each type of field
      */
     public function setValue($value)
@@ -111,7 +116,7 @@ class NodeElement extends TraversableElement
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasAttribute($name)
     {
@@ -148,6 +153,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Clicks current node.
+     *
+     * @return void
      */
     public function click()
     {
@@ -156,6 +163,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Presses current button.
+     *
+     * @return void
      */
     public function press()
     {
@@ -164,6 +173,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Double-clicks current node.
+     *
+     * @return void
      */
     public function doubleClick()
     {
@@ -172,6 +183,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Right-clicks current node.
+     *
+     * @return void
      */
     public function rightClick()
     {
@@ -180,6 +193,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Checks current node if it's a checkbox field.
+     *
+     * @return void
      */
     public function check()
     {
@@ -188,6 +203,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Unchecks current node if it's a checkbox field.
+     *
+     * @return void
      */
     public function uncheck()
     {
@@ -199,11 +216,11 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on any other elements is not allowed.
      *
-     * @return boolean
+     * @return bool
      */
     public function isChecked()
     {
-        return (boolean) $this->getDriver()->isChecked($this->getXpath());
+        return (bool) $this->getDriver()->isChecked($this->getXpath());
     }
 
     /**
@@ -216,8 +233,10 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on any other elements is not allowed.
      *
-     * @param string  $option
-     * @param boolean $multiple whether the option should be added to the selection for multiple selects
+     * @param string $option
+     * @param bool   $multiple whether the option should be added to the selection for multiple selects
+     *
+     * @return void
      *
      * @throws ElementNotFoundException when the option is not found in the select box
      */
@@ -243,11 +262,11 @@ class NodeElement extends TraversableElement
      *
      * Calling this method on any other elements is not allowed.
      *
-     * @return boolean
+     * @return bool
      */
     public function isSelected()
     {
-        return (boolean) $this->getDriver()->isSelected($this->getXpath());
+        return (bool) $this->getDriver()->isSelected($this->getXpath());
     }
 
     /**
@@ -256,6 +275,8 @@ class NodeElement extends TraversableElement
      * Calling this method on any other elements than file input is not allowed.
      *
      * @param string $path path to file (local)
+     *
+     * @return void
      */
     public function attachFile($path)
     {
@@ -265,15 +286,17 @@ class NodeElement extends TraversableElement
     /**
      * Checks whether current node is visible on page.
      *
-     * @return boolean
+     * @return bool
      */
     public function isVisible()
     {
-        return (boolean) $this->getDriver()->isVisible($this->getXpath());
+        return (bool) $this->getDriver()->isVisible($this->getXpath());
     }
 
     /**
      * Simulates a mouse over on the element.
+     *
+     * @return void
      */
     public function mouseOver()
     {
@@ -284,6 +307,8 @@ class NodeElement extends TraversableElement
      * Drags current node onto other node.
      *
      * @param ElementInterface $destination other node
+     *
+     * @return void
      */
     public function dragTo(ElementInterface $destination)
     {
@@ -292,6 +317,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Brings focus to element.
+     *
+     * @return void
      */
     public function focus()
     {
@@ -300,6 +327,8 @@ class NodeElement extends TraversableElement
 
     /**
      * Removes focus from element.
+     *
+     * @return void
      */
     public function blur()
     {
@@ -313,6 +342,8 @@ class NodeElement extends TraversableElement
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
      *
      * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyPress($char, $modifier = null)
     {
@@ -326,6 +357,8 @@ class NodeElement extends TraversableElement
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
      *
      * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyDown($char, $modifier = null)
     {
@@ -339,6 +372,8 @@ class NodeElement extends TraversableElement
      * @param string|null $modifier keyboard modifier (could be 'ctrl', 'alt', 'shift' or 'meta')
      *
      * @phpstan-param KeyModifier::*|null $modifier
+     *
+     * @return void
      */
     public function keyUp($char, $modifier = null)
     {
@@ -349,6 +384,8 @@ class NodeElement extends TraversableElement
      * Submits the form.
      *
      * Calling this method on anything else than form elements is not allowed.
+     *
+     * @return void
      */
     public function submit()
     {

--- a/src/Element/TraversableElement.php
+++ b/src/Element/TraversableElement.php
@@ -36,7 +36,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator link id, title, text or image alt
      *
-     * @return boolean
+     * @return bool
      */
     public function hasLink($locator)
     {
@@ -60,6 +60,8 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator link id, title, text or image alt
      *
+     * @return void
+     *
      * @throws ElementNotFoundException
      */
     public function clickLink($locator)
@@ -78,7 +80,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator button id, value or alt
      *
-     * @return boolean
+     * @return bool
      */
     public function hasButton($locator)
     {
@@ -102,6 +104,8 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator button id, value or alt
      *
+     * @return void
+     *
      * @throws ElementNotFoundException
      */
     public function pressButton($locator)
@@ -120,7 +124,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return boolean
+     * @return bool
      */
     public function hasField($locator)
     {
@@ -145,6 +149,8 @@ abstract class TraversableElement extends Element
      * @param string $locator input id, name or label
      * @param string $value   value
      *
+     * @return void
+     *
      * @throws ElementNotFoundException
      *
      * @see NodeElement::setValue
@@ -165,7 +171,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return boolean
+     * @return bool
      *
      * @see NodeElement::isChecked
      */
@@ -181,7 +187,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
-     * @return boolean
+     * @return bool
      *
      * @see NodeElement::isChecked
      */
@@ -196,6 +202,8 @@ abstract class TraversableElement extends Element
      * Checks checkbox with specified locator.
      *
      * @param string $locator input id, name or label
+     *
+     * @return void
      *
      * @throws ElementNotFoundException
      */
@@ -215,6 +223,8 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      *
+     * @return void
+     *
      * @throws ElementNotFoundException
      */
     public function uncheckField($locator)
@@ -233,7 +243,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator select id, name or label
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSelect($locator)
     {
@@ -243,9 +253,11 @@ abstract class TraversableElement extends Element
     /**
      * Selects option from select field with specified locator.
      *
-     * @param string  $locator  input id, name or label
-     * @param string  $value    option value
-     * @param boolean $multiple select multiple options
+     * @param string $locator  input id, name or label
+     * @param string $value    option value
+     * @param bool   $multiple select multiple options
+     *
+     * @return void
      *
      * @throws ElementNotFoundException
      *
@@ -267,7 +279,7 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator table id or caption
      *
-     * @return boolean
+     * @return bool
      */
     public function hasTable($locator)
     {
@@ -279,6 +291,8 @@ abstract class TraversableElement extends Element
      *
      * @param string $locator input id, name or label
      * @param string $path    path to file
+     *
+     * @return void
      *
      * @throws ElementNotFoundException
      *

--- a/src/Exception/ElementException.php
+++ b/src/Exception/ElementException.php
@@ -23,6 +23,9 @@ use Behat\Mink\Element\Element;
  */
 class ElementException extends Exception
 {
+    /**
+     * @var Element
+     */
     private $element;
 
     /**

--- a/src/Exception/ExpectationException.php
+++ b/src/Exception/ExpectationException.php
@@ -22,7 +22,13 @@ use Behat\Mink\Session;
  */
 class ExpectationException extends Exception
 {
+    /**
+     * @var Session|null
+     */
     private $session;
+    /**
+     * @var DriverInterface
+     */
     private $driver;
 
     /**

--- a/src/Mink.php
+++ b/src/Mink.php
@@ -54,6 +54,8 @@ class Mink
      *
      * @param string  $name
      * @param Session $session
+     *
+     * @return void
      */
     public function registerSession($name, Session $session)
     {
@@ -67,7 +69,7 @@ class Mink
      *
      * @param string $name
      *
-     * @return boolean
+     * @return bool
      */
     public function hasSession($name)
     {
@@ -78,6 +80,8 @@ class Mink
      * Sets default session name to use.
      *
      * @param string $name name of the registered session
+     *
+     * @return void
      *
      * @throws \InvalidArgumentException
      */
@@ -150,6 +154,8 @@ class Mink
 
     /**
      * Resets all started sessions.
+     *
+     * @return void
      */
     public function resetSessions()
     {
@@ -162,6 +168,8 @@ class Mink
 
     /**
      * Restarts all started sessions.
+     *
+     * @return void
      */
     public function restartSessions()
     {
@@ -174,6 +182,8 @@ class Mink
 
     /**
      * Stops all started sessions.
+     *
+     * @return void
      */
     public function stopSessions()
     {

--- a/src/Selector/NamedSelector.php
+++ b/src/Selector/NamedSelector.php
@@ -19,6 +19,9 @@ use Behat\Mink\Selector\Xpath\Escaper;
  */
 class NamedSelector implements SelectorInterface
 {
+    /**
+     * @var array<string, string>
+     */
     private $replacements = array(
         // simple replacements
         '%lowercaseType%' => "translate(./@type, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')",
@@ -48,6 +51,9 @@ class NamedSelector implements SelectorInterface
         '%imgAltMatch%' => './/img[%altMatch%]',
     );
 
+    /**
+     * @var array<string, string>
+     */
     private $selectors = array(
         'fieldset' => <<<XPATH
 .//fieldset
@@ -159,6 +165,9 @@ XPATH
 .//*[%idOrNameMatch%]
 XPATH
     );
+    /**
+     * @var Escaper
+     */
     private $xpathEscaper;
 
     /**
@@ -182,6 +191,8 @@ XPATH
      *
      * @param string $name  name for selector
      * @param string $xpath xpath expression
+     *
+     * @return void
      */
     public function registerNamedXpath($name, $xpath)
     {
@@ -241,7 +252,7 @@ XPATH
      *
      * Because the %idOrNameMatch% replacement consumes the %idMatch% replacement, it must be defined afterwards.
      *
-     * You may then use this in an a Named XPath:
+     * You may then use this in a Named XPath:
      *
      *     .//fieldset[%idOrNameMatch%]
      *
@@ -251,13 +262,15 @@ XPATH
      *
      * @param string $from The source, typically a string wrapped in % markers
      * @param string $to The translation
+     *
+     * @return void
      */
     public function registerReplacement($from, $to)
     {
         $this->replacements[$from] = strtr($to, $this->replacements);
     }
 
-    private function escapeLocator($locator)
+    private function escapeLocator(string $locator): string
     {
         // If the locator looks like an escaped one, don't escape it again for BC reasons.
         if (

--- a/src/Selector/SelectorsHandler.php
+++ b/src/Selector/SelectorsHandler.php
@@ -19,13 +19,19 @@ use Behat\Mink\Selector\Xpath\Escaper;
  */
 class SelectorsHandler
 {
-    private $selectors;
+    /**
+     * @var array<string, SelectorInterface>
+     */
+    private $selectors = [];
+    /**
+     * @var Escaper
+     */
     private $escaper;
 
     /**
      * Initializes selectors handler.
      *
-     * @param SelectorInterface[] $selectors default selectors to register
+     * @param array<string, SelectorInterface> $selectors default selectors to register
      */
     public function __construct(array $selectors = array())
     {
@@ -45,6 +51,8 @@ class SelectorsHandler
      *
      * @param string            $name     selector engine name
      * @param SelectorInterface $selector selector engine instance
+     *
+     * @return void
      */
     public function registerSelector($name, SelectorInterface $selector)
     {
@@ -56,7 +64,7 @@ class SelectorsHandler
      *
      * @param string $name selector engine name
      *
-     * @return boolean
+     * @return bool
      */
     public function isSelectorRegistered($name)
     {
@@ -94,7 +102,7 @@ class SelectorsHandler
      * Translates selector with specified name to XPath.
      *
      * @param string       $selector selector engine name (registered)
-     * @param string|array $locator  selector locator (an array or a string depending of the selector being used)
+     * @param string|array $locator  selector locator (an array or a string depending on the selector being used)
      *
      * @return string
      */

--- a/src/Session.php
+++ b/src/Session.php
@@ -21,8 +21,17 @@ use Behat\Mink\Element\DocumentElement;
  */
 class Session
 {
+    /**
+     * @var DriverInterface
+     */
     private $driver;
+    /**
+     * @var DocumentElement
+     */
     private $page;
+    /**
+     * @var SelectorsHandler
+     */
     private $selectorsHandler;
 
     /**
@@ -47,7 +56,7 @@ class Session
     /**
      * Checks whether session (driver) was started.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStarted()
     {
@@ -64,6 +73,8 @@ class Session
      * - setBasicAuth()
      * - reset()
      * - stop()
+     *
+     * @return void
      */
     public function start()
     {
@@ -72,6 +83,8 @@ class Session
 
     /**
      * Stops session driver.
+     *
+     * @return void
      */
     public function stop()
     {
@@ -80,6 +93,8 @@ class Session
 
     /**
      * Restart session driver.
+     *
+     * @return void
      */
     public function restart()
     {
@@ -97,6 +112,8 @@ class Session
      * - setBasicAuth()
      * - reset()
      * - stop()
+     *
+     * @return void
      */
     public function reset()
     {
@@ -137,6 +154,8 @@ class Session
      * Visit specified URL and automatically start session if not already running.
      *
      * @param string $url url of the page
+     *
+     * @return void
      */
     public function visit($url)
     {
@@ -151,8 +170,10 @@ class Session
     /**
      * Sets HTTP Basic authentication parameters.
      *
-     * @param string|boolean $user     user name or false to disable authentication
-     * @param string         $password password
+     * @param string|false $user     user name or false to disable authentication
+     * @param string       $password password
+     *
+     * @return void
      */
     public function setBasicAuth($user, $password = '')
     {
@@ -164,6 +185,8 @@ class Session
      *
      * @param string $name
      * @param string $value
+     *
+     * @return void
      */
     public function setRequestHeader($name, $value)
     {
@@ -208,6 +231,8 @@ class Session
      *
      * @param string      $name
      * @param string|null $value
+     *
+     * @return void
      */
     public function setCookie($name, $value = null)
     {
@@ -279,6 +304,8 @@ class Session
 
     /**
      * Reloads current session page.
+     *
+     * @return void
      */
     public function reload()
     {
@@ -287,6 +314,8 @@ class Session
 
     /**
      * Moves backward 1 page in history.
+     *
+     * @return void
      */
     public function back()
     {
@@ -295,6 +324,8 @@ class Session
 
     /**
      * Moves forward 1 page in history.
+     *
+     * @return void
      */
     public function forward()
     {
@@ -305,6 +336,8 @@ class Session
      * Switches to specific browser window.
      *
      * @param string|null $name window name (null for switching back to main window)
+     *
+     * @return void
      */
     public function switchToWindow($name = null)
     {
@@ -315,6 +348,8 @@ class Session
      * Switches to specific iFrame.
      *
      * @param string|null $name iframe name (null for switching back)
+     *
+     * @return void
      */
     public function switchToIFrame($name = null)
     {
@@ -325,6 +360,8 @@ class Session
      * Execute JS in browser.
      *
      * @param string $script javascript
+     *
+     * @return void
      */
     public function executeScript($script)
     {
@@ -362,6 +399,8 @@ class Session
      * @param int         $width  set the window width, measured in pixels
      * @param int         $height set the window height, measured in pixels
      * @param string|null $name   window name (null for the main window)
+     *
+     * @return void
      */
     public function resizeWindow($width, $height, $name = null)
     {
@@ -372,6 +411,8 @@ class Session
      * Maximize the window if it is not maximized already.
      *
      * @param string|null $name window name (null for the main window)
+     *
+     * @return void
      */
     public function maximizeWindow($name = null)
     {

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -27,6 +27,9 @@ use Behat\Mink\Exception\ElementTextException;
  */
 class WebAssert
 {
+    /**
+     * @var Session
+     */
     protected $session;
 
     /**
@@ -44,6 +47,8 @@ class WebAssert
      *
      * @param string $page
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function addressEquals($page)
@@ -58,6 +63,8 @@ class WebAssert
      * Checks that current session address is not equals to provided one.
      *
      * @param string $page
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -74,6 +81,8 @@ class WebAssert
      *
      * @param string $regex
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function addressMatches($regex)
@@ -89,6 +98,8 @@ class WebAssert
      *
      * @param string $name  cookie name
      * @param string $value cookie value
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -107,6 +118,8 @@ class WebAssert
      *
      * @param string $name cookie name
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function cookieExists($name)
@@ -119,6 +132,8 @@ class WebAssert
      * Checks that current response code equals to provided one.
      *
      * @param int $code
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -134,6 +149,8 @@ class WebAssert
      * Checks that current response code not equals to provided one.
      *
      * @param int $code
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -151,6 +168,8 @@ class WebAssert
      * @param string $name
      * @param string $value
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function responseHeaderEquals($name, $value)
@@ -166,6 +185,8 @@ class WebAssert
      *
      * @param string $name
      * @param string $value
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -183,6 +204,8 @@ class WebAssert
      * @param string $name
      * @param string $value
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function responseHeaderContains($name, $value)
@@ -198,6 +221,8 @@ class WebAssert
      *
      * @param string $name
      * @param string $value
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -215,6 +240,8 @@ class WebAssert
      * @param string $name
      * @param string $regex
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function responseHeaderMatches($name, $regex)
@@ -230,6 +257,8 @@ class WebAssert
      *
      * @param string $name
      * @param string $regex
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -250,6 +279,8 @@ class WebAssert
      *
      * @param string $text
      *
+     * @return void
+     *
      * @throws ResponseTextException
      */
     public function pageTextContains($text)
@@ -263,9 +294,11 @@ class WebAssert
     }
 
     /**
-     * Checks that current page does not contains text.
+     * Checks that current page does not contain text.
      *
      * @param string $text
+     *
+     * @return void
      *
      * @throws ResponseTextException
      */
@@ -284,6 +317,8 @@ class WebAssert
      *
      * @param string $regex
      *
+     * @return void
+     *
      * @throws ResponseTextException
      */
     public function pageTextMatches($regex)
@@ -295,9 +330,11 @@ class WebAssert
     }
 
     /**
-     * Checks that current page text does not matches regex.
+     * Checks that current page text does not match regex.
      *
      * @param string $regex
+     *
+     * @return void
      *
      * @throws ResponseTextException
      */
@@ -314,6 +351,8 @@ class WebAssert
      *
      * @param string $text
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function responseContains($text)
@@ -328,6 +367,8 @@ class WebAssert
      * Checks that page HTML (response content) does not contains text.
      *
      * @param string $text
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -344,6 +385,8 @@ class WebAssert
      *
      * @param string $regex
      *
+     * @return void
+     *
      * @throws ExpectationException
      */
     public function responseMatches($regex)
@@ -357,7 +400,9 @@ class WebAssert
     /**
      * Checks that page HTML (response content) does not matches regex.
      *
-     * @param $regex
+     * @param string $regex
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -372,10 +417,12 @@ class WebAssert
     /**
      * Checks that there is specified number of specific elements on the page.
      *
-     * @param string           $selectorType element selector type (css, xpath)
-     * @param string|array     $selector     element selector
-     * @param int              $count        expected count
-     * @param ElementInterface $container    document to check against
+     * @param string                $selectorType element selector type (css, xpath)
+     * @param string|array          $selector     element selector
+     * @param int                   $count        expected count
+     * @param ElementInterface|null $container    document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -397,9 +444,9 @@ class WebAssert
     /**
      * Checks that specific element exists on the current page.
      *
-     * @param string           $selectorType element selector type (css, xpath)
-     * @param string|array     $selector     element selector
-     * @param ElementInterface $container    document to check against
+     * @param string                $selectorType element selector type (css, xpath)
+     * @param string|array          $selector     element selector
+     * @param ElementInterface|null $container    document to check against
      *
      * @return NodeElement
      *
@@ -424,9 +471,11 @@ class WebAssert
     /**
      * Checks that specific element does not exists on the current page.
      *
-     * @param string           $selectorType element selector type (css, xpath)
-     * @param string|array     $selector     element selector
-     * @param ElementInterface $container    document to check against
+     * @param string                $selectorType element selector type (css, xpath)
+     * @param string|array          $selector     element selector
+     * @param ElementInterface|null $container    document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -450,7 +499,10 @@ class WebAssert
      * @param string|array $selector     element selector
      * @param string       $text         expected text
      *
+     * @return void
+     *
      * @throws ElementTextException
+     * @throws ElementNotFoundException
      */
     public function elementTextContains($selectorType, $selector, $text)
     {
@@ -474,7 +526,10 @@ class WebAssert
      * @param string|array $selector     element selector
      * @param string       $text         expected text
      *
+     * @return void
+     *
      * @throws ElementTextException
+     * @throws ElementNotFoundException
      */
     public function elementTextNotContains($selectorType, $selector, $text)
     {
@@ -498,7 +553,10 @@ class WebAssert
      * @param string|array $selector     element selector
      * @param string       $html         expected text
      *
+     * @return void
+     *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementContains($selectorType, $selector, $html)
     {
@@ -522,7 +580,10 @@ class WebAssert
      * @param string|array $selector     element selector
      * @param string       $html         expected text
      *
+     * @return void
+     *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementNotContains($selectorType, $selector, $html)
     {
@@ -549,6 +610,7 @@ class WebAssert
      * @return NodeElement
      *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementAttributeExists($selectorType, $selector, $attribute)
     {
@@ -575,6 +637,7 @@ class WebAssert
      * @return NodeElement
      *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementAttributeNotExists($selectorType, $selector, $attribute)
     {
@@ -599,7 +662,10 @@ class WebAssert
      * @param string       $attribute
      * @param string       $text
      *
+     * @return void
+     *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementAttributeContains($selectorType, $selector, $attribute, $text)
     {
@@ -625,7 +691,10 @@ class WebAssert
      * @param string       $attribute
      * @param string       $text
      *
+     * @return void
+     *
      * @throws ElementHtmlException
+     * @throws ElementNotFoundException
      */
     public function elementAttributeNotContains($selectorType, $selector, $attribute, $text)
     {
@@ -646,8 +715,8 @@ class WebAssert
     /**
      * Checks that specific field exists on the current page.
      *
-     * @param string             $field     field id|name|label|value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param TraversableElement|null $container document to check against
      *
      * @return NodeElement
      *
@@ -666,10 +735,12 @@ class WebAssert
     }
 
     /**
-     * Checks that specific field does not exists on the current page.
+     * Checks that specific field does not exist on the current page.
      *
-     * @param string             $field     field id|name|label|value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param TraversableElement|null $container document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -684,9 +755,11 @@ class WebAssert
     /**
      * Checks that specific field have provided value.
      *
-     * @param string             $field     field id|name|label|value
-     * @param string             $value     field value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param string                  $value     field value
+     * @param TraversableElement|null $container document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -704,9 +777,11 @@ class WebAssert
     /**
      * Checks that specific field have provided value.
      *
-     * @param string             $field     field id|name|label|value
-     * @param string             $value     field value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param string                  $value     field value
+     * @param TraversableElement|null $container document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -724,8 +799,10 @@ class WebAssert
     /**
      * Checks that specific checkbox is checked.
      *
-     * @param string             $field     field id|name|label|value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param TraversableElement|null $container document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -739,8 +816,10 @@ class WebAssert
     /**
      * Checks that specific checkbox is unchecked.
      *
-     * @param string             $field     field id|name|label|value
-     * @param TraversableElement $container document to check against
+     * @param string                  $field     field id|name|label|value
+     * @param TraversableElement|null $container document to check against
+     *
+     * @return void
      *
      * @throws ExpectationException
      */
@@ -783,6 +862,8 @@ class WebAssert
      * @param bool   $condition
      * @param string $message   Failure message
      *
+     * @return void
+     *
      * @throws ExpectationException when the condition is not fulfilled
      */
     private function assert($condition, $message)
@@ -799,6 +880,8 @@ class WebAssert
      *
      * @param bool   $condition
      * @param string $message   Failure message
+     *
+     * @return void
      *
      * @throws ResponseTextException when the condition is not fulfilled
      */
@@ -818,6 +901,8 @@ class WebAssert
      * @param string  $message   Failure message
      * @param Element $element
      *
+     * @return void
+     *
      * @throws ElementHtmlException when the condition is not fulfilled
      */
     private function assertElement($condition, $message, Element $element)
@@ -835,6 +920,8 @@ class WebAssert
      * @param bool    $condition
      * @param string  $message   Failure message
      * @param Element $element
+     *
+     * @return void
      *
      * @throws ElementTextException when the condition is not fulfilled
      */


### PR DESCRIPTION
- `@return void` is added on all methods that return void
- CoreDriver uses actual `@return` instead of `@inheritdoc` to play well with the way the Symfony DebugClassLoader hints child classes to add return types
- methods of CoreDriver that should not be overriden in drivers (as checked by the driver-testsuite already) have a `@final` annotation now.
- all properties have their type defined in phpdoc
- some wrong argument types have been fixed (cases defining an optional argument as non-nullable in phpdoc while the default value is `null`)
- `boolean` is changed to `bool` to match the native name in PHP
- some missing `@throws` were added in WebAssert where they made sense