### PR TITLE
Make the ElementFinder internal

### DIFF
--- a/src/Element/ElementFinder.php
+++ b/src/Element/ElementFinder.php
@@ -16,6 +16,7 @@ use Behat\Mink\Selector\Xpath\Manipulator;
 
 /**
  * @final
+ * @internal
  */
 class ElementFinder
 {
@@ -32,10 +33,10 @@ class ElementFinder
      */
     private $xpathManipulator;
 
-    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler = null, Manipulator $xpathManipulator = null)
+    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler, Manipulator $xpathManipulator = null)
     {
         $this->driver = $driver;
-        $this->selectorsHandler = $selectorsHandler ?? new SelectorsHandler();
+        $this->selectorsHandler = $selectorsHandler;
         $this->xpathManipulator = $xpathManipulator ?? new Manipulator();
     }
 
@@ -59,13 +60,5 @@ class ElementFinder
         $xpath = $this->xpathManipulator->prepend($xpath, $parentXpath);
 
         return $this->driver->find($xpath);
-    }
-
-    /**
-     * @internal
-     */
-    public function getSelectorsHandler(): SelectorsHandler
-    {
-        return $this->selectorsHandler;
     }
 }

--- a/src/Session.php
+++ b/src/Session.php
@@ -34,22 +34,16 @@ class Session
      * @var ElementFinder
      */
     private $elementFinder;
-
     /**
-     * @param ElementFinder|SelectorsHandler|null $elementFinder
+     * @var SelectorsHandler
      */
-    public function __construct(DriverInterface $driver, $elementFinder = null)
-    {
-        if ($elementFinder instanceof SelectorsHandler) {
-            $elementFinder = new ElementFinder($driver, $elementFinder);
-        } elseif ($elementFinder === null) {
-            $elementFinder = new ElementFinder($driver);
-        } elseif (!$elementFinder instanceof ElementFinder) {
-            throw new \TypeError(sprintf('Argument #2 of %s expects %s|%s|null, %s given.', __METHOD__, ElementFinder::class, SelectorsHandler::class, \is_object($elementFinder) ? get_class($elementFinder) : gettype($elementFinder)));
-        }
+    private $selectorsHandler;
 
+    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler = null)
+    {
         $this->driver = $driver;
-        $this->elementFinder = $elementFinder;
+        $this->selectorsHandler = $selectorsHandler ?? new SelectorsHandler();
+        $this->elementFinder = new ElementFinder($driver, $this->selectorsHandler);
         $this->page = new DocumentElement($this);
 
         $driver->setSession($this);
@@ -155,11 +149,13 @@ class Session
      *
      * @return SelectorsHandler
      *
-     * @internal since 1.11
+     * @deprecated since 1.11
      */
     public function getSelectorsHandler()
     {
-        return $this->elementFinder->getSelectorsHandler();
+        @trigger_error(sprintf('The method %s is deprecated as of 1.11 and will be removed in 2.0', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->selectorsHandler;
     }
 
     /**

--- a/tests/Element/ElementTest.php
+++ b/tests/Element/ElementTest.php
@@ -33,11 +33,10 @@ abstract class ElementTest extends TestCase
     protected function prepareSession(): void
     {
         $this->driver = $this->getMockBuilder('Behat\Mink\Driver\DriverInterface')->getMock();
-        $this->driver
-            ->expects($this->once())
-            ->method('setSession');
 
         $this->elementFinder = $this->createMock(ElementFinder::class);
-        $this->session = new Session($this->driver, $this->elementFinder);
+        $this->session = $this->createStub(Session::class);
+        $this->session->method('getDriver')->willReturn($this->driver);
+        $this->session->method('getElementFinder')->willReturn($this->elementFinder);
     }
 }

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -46,11 +46,17 @@ class SessionTest extends TestCase
         $this->assertInstanceOf('Behat\Mink\Element\DocumentElement', $this->session->getPage());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetSelectorsHandler()
     {
         $this->assertSame($this->selectorsHandler, $this->session->getSelectorsHandler());
     }
 
+    /**
+     * @group legacy
+     */
     public function testInstantiateWithoutOptionalDeps()
     {
         $session = new Session($this->driver);


### PR DESCRIPTION
The ElementFinder does not need to be a public extension point of the Session. The extension point is already covered by the SelectorsHandler. And keeping it internal avoids mistakes where it would not use the same driver than the session.