### PR TITLE
Define the callback signature for waitFor

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -4,6 +4,7 @@ parameters:
         - src
         - tests
     checkMissingIterableValueType: false
+    checkMissingCallableSignature: true
     treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - '#^Method Behat\\Mink\\Tests\\[^:]+Test(Case)?\:\:test\w*\(\) has no return type specified\.$#'

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -106,9 +106,6 @@ abstract class Element implements ElementInterface
         return 1 === count($this->getDriver()->find($this->getXpath()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function waitFor($timeout, $callback)
     {
         if (!is_callable($callback)) {

--- a/src/Element/ElementInterface.php
+++ b/src/Element/ElementInterface.php
@@ -55,13 +55,22 @@ interface ElementInterface
     public function isValid();
 
     /**
-     * Waits for an element(-s) to appear and returns it.
+     * Waits for a value to be available and returns it.
      *
-     * @param int|float $timeout  Maximal allowed waiting time in seconds.
-     * @param callable  $callback Callback, which result is both used as waiting condition and returned.
-     *                            Will receive reference to `this element` as first argument.
+     * A falsy value returned by the callback is considered not found and will
+     * retry after some waiting time, until a value is found or the timeout is
+     * reached.
+     * When the timeout is reached, the falsy value of the last attempt is returned.
+     *
+     * @template T
+     *
+     * @param int|float           $timeout  Maximal allowed waiting time in seconds.
+     * @param callable(static): T $callback Callback, which result is both used as waiting condition and returned.
+     *                                      Will receive reference to `this element` as first argument.
      *
      * @return mixed
+     *
+     * @phpstan-return T
      *
      * @throws \InvalidArgumentException When invalid callback given.
      */


### PR DESCRIPTION
This also enforces that all callables define their signature in the phpstan configuration.