### PR TITLE
Support Throwable for the previous exception

### DIFF
--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -22,9 +22,9 @@ class DriverException extends Exception
      *
      * @param string          $message
      * @param int             $code
-     * @param \Exception|null $previous
+     * @param \Throwable|null $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct($message, $code = 0, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/ElementHtmlException.php
+++ b/src/Exception/ElementHtmlException.php
@@ -34,9 +34,9 @@ class ElementHtmlException extends ExpectationException
      * @param string                  $message   optional message
      * @param DriverInterface|Session $driver    driver instance
      * @param Element                 $element   element
-     * @param \Exception|null         $exception expectation exception
+     * @param \Throwable|null         $exception expectation exception
      */
-    public function __construct($message, $driver, Element $element, \Exception $exception = null)
+    public function __construct($message, $driver, Element $element, \Throwable $exception = null)
     {
         $this->element = $element;
 

--- a/src/Exception/ExpectationException.php
+++ b/src/Exception/ExpectationException.php
@@ -36,9 +36,9 @@ class ExpectationException extends Exception
      *
      * @param string                  $message   optional message
      * @param DriverInterface|Session $driver    driver instance (or session for BC)
-     * @param \Exception|null         $exception expectation exception
+     * @param \Throwable|null         $exception expectation exception
      */
-    public function __construct($message, $driver, \Exception $exception = null)
+    public function __construct($message, $driver, \Throwable $exception = null)
     {
         if ($driver instanceof Session) {
             @trigger_error('Passing a Session object to the ExpectationException constructor is deprecated as of Mink 1.7. Pass the driver instead.', E_USER_DEPRECATED);

--- a/src/Exception/UnsupportedDriverActionException.php
+++ b/src/Exception/UnsupportedDriverActionException.php
@@ -24,9 +24,9 @@ class UnsupportedDriverActionException extends DriverException
      *
      * @param string          $template what is unsupported?
      * @param DriverInterface $driver   driver instance
-     * @param \Exception|null $previous previous exception
+     * @param \Throwable|null $previous previous exception
      */
-    public function __construct($template, DriverInterface $driver, \Exception $previous = null)
+    public function __construct($template, DriverInterface $driver, \Throwable $previous = null)
     {
         $message = sprintf($template, get_class($driver));
 


### PR DESCRIPTION
This matches what is done in PHP's `Exception` constructor.