### PR TITLE
Fixed argument type in switchToIFrame() to be integer.

### DIFF
--- a/src/Driver/CoreDriver.php
+++ b/src/Driver/CoreDriver.php
@@ -160,14 +160,14 @@ abstract class CoreDriver implements DriverInterface
     }
 
     /**
-     * @param string|null $name
+     * @param int|null $name
      *
      * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    public function switchToIFrame(?string $name = null)
+    public function switchToIFrame(?int $name = null)
     {
         throw new UnsupportedDriverActionException('iFrames management is not supported by %s', $this);
     }

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -184,14 +184,14 @@ interface DriverInterface
     /**
      * Switches to specific iFrame.
      *
-     * @param string|null $name iframe name (null for switching back)
+     * @param int|null $name iframe id (null for switching back)
      *
      * @return void
      *
      * @throws UnsupportedDriverActionException When operation not supported by the driver
      * @throws DriverException                  When the operation cannot be done
      */
-    public function switchToIFrame(?string $name = null);
+    public function switchToIFrame(?int $name = null);
 
     /**
      * Sets specific request header on client.

--- a/src/Session.php
+++ b/src/Session.php
@@ -355,11 +355,11 @@ class Session
     /**
      * Switches to specific iFrame.
      *
-     * @param string|null $name iframe name (null for switching back)
+     * @param int|null $name iframe id (null for switching back)
      *
      * @return void
      */
-    public function switchToIFrame(?string $name = null)
+    public function switchToIFrame(?int $name = null)
     {
         $this->driver->switchToIFrame($name);
     }

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -300,9 +300,9 @@ class SessionTest extends TestCase
     {
         $this->driver->expects($this->once())
             ->method('switchToIFrame')
-            ->with('test');
+            ->with(0);
 
-        $this->session->switchToIFrame('test');
+        $this->session->switchToIFrame(0);
     }
 
     public function testExecuteScript()


### PR DESCRIPTION
Release `1.11.0` introduced strict types.

With that, the `switchToIFrame(string? $id)` method started to fail on consumer projects using `w3c` = `true` because the expected `$id` argument has a type `string` instead of expected `int`. 

According to https://www.w3.org/TR/webdriver/#switch-to-frame, the `$id` is expected to be an integer.

This PR updates `string?` with `int?`.

Note that downstream project `MinkSelenium2Driver` have the same issue propagated after the recent release `1.7.0`: https://github.com/minkphp/MinkSelenium2Driver/blob/master/src/Selenium2Driver.php#L431