### PR TITLE
Fix PHP RFC: Deprecate implicitly nullable parameter types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         composer_flags: [ '' ]
         minimum_stability: [ '' ]
         symfony_deprecations_helper: [ '' ]

--- a/src/Element/ElementFinder.php
+++ b/src/Element/ElementFinder.php
@@ -33,7 +33,7 @@ class ElementFinder
      */
     private $xpathManipulator;
 
-    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler, Manipulator $xpathManipulator = null)
+    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler, ?Manipulator $xpathManipulator = null)
     {
         $this->driver = $driver;
         $this->selectorsHandler = $selectorsHandler;

--- a/src/Exception/DriverException.php
+++ b/src/Exception/DriverException.php
@@ -24,7 +24,7 @@ class DriverException extends Exception
      * @param int             $code
      * @param \Throwable|null $previous
      */
-    public function __construct(string $message, int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/ElementHtmlException.php
+++ b/src/Exception/ElementHtmlException.php
@@ -36,7 +36,7 @@ class ElementHtmlException extends ExpectationException
      * @param Element                 $element   element
      * @param \Throwable|null         $exception expectation exception
      */
-    public function __construct(string $message, $driver, Element $element, \Throwable $exception = null)
+    public function __construct(string $message, $driver, Element $element, ?\Throwable $exception = null)
     {
         $this->element = $element;
 

--- a/src/Exception/ExpectationException.php
+++ b/src/Exception/ExpectationException.php
@@ -38,7 +38,7 @@ class ExpectationException extends Exception
      * @param DriverInterface|Session $driver    driver instance (or session for BC)
      * @param \Throwable|null         $exception expectation exception
      */
-    public function __construct(string $message, $driver, \Throwable $exception = null)
+    public function __construct(string $message, $driver, ?\Throwable $exception = null)
     {
         if ($driver instanceof Session) {
             @trigger_error('Passing a Session object to the ExpectationException constructor is deprecated as of Mink 1.7. Pass the driver instead.', E_USER_DEPRECATED);

--- a/src/Exception/UnsupportedDriverActionException.php
+++ b/src/Exception/UnsupportedDriverActionException.php
@@ -26,7 +26,7 @@ class UnsupportedDriverActionException extends DriverException
      * @param DriverInterface $driver   driver instance
      * @param \Throwable|null $previous previous exception
      */
-    public function __construct(string $template, DriverInterface $driver, \Throwable $previous = null)
+    public function __construct(string $template, DriverInterface $driver, ?\Throwable $previous = null)
     {
         $message = sprintf($template, get_class($driver));
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -39,7 +39,7 @@ class Session
      */
     private $selectorsHandler;
 
-    public function __construct(DriverInterface $driver, SelectorsHandler $selectorsHandler = null)
+    public function __construct(DriverInterface $driver, ?SelectorsHandler $selectorsHandler = null)
     {
         $this->driver = $driver;
         $this->selectorsHandler = $selectorsHandler ?? new SelectorsHandler();

--- a/src/WebAssert.php
+++ b/src/WebAssert.php
@@ -426,7 +426,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function elementsCount(string $selectorType, $selector, int $count, ElementInterface $container = null)
+    public function elementsCount(string $selectorType, $selector, int $count, ?ElementInterface $container = null)
     {
         $container = $container ?: $this->session->getPage();
         $nodes = $container->findAll($selectorType, $selector);
@@ -452,7 +452,7 @@ class WebAssert
      *
      * @throws ElementNotFoundException
      */
-    public function elementExists(string $selectorType, $selector, ElementInterface $container = null)
+    public function elementExists(string $selectorType, $selector, ?ElementInterface $container = null)
     {
         $container = $container ?: $this->session->getPage();
         $node = $container->find($selectorType, $selector);
@@ -479,7 +479,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function elementNotExists(string $selectorType, $selector, ElementInterface $container = null)
+    public function elementNotExists(string $selectorType, $selector, ?ElementInterface $container = null)
     {
         $container = $container ?: $this->session->getPage();
         $node = $container->find($selectorType, $selector);
@@ -722,7 +722,7 @@ class WebAssert
      *
      * @throws ElementNotFoundException
      */
-    public function fieldExists(string $field, TraversableElement $container = null)
+    public function fieldExists(string $field, ?TraversableElement $container = null)
     {
         $container = $container ?: $this->session->getPage();
         $node = $container->findField($field);
@@ -744,7 +744,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function fieldNotExists(string $field, TraversableElement $container = null)
+    public function fieldNotExists(string $field, ?TraversableElement $container = null)
     {
         $container = $container ?: $this->session->getPage();
         $node = $container->findField($field);
@@ -763,7 +763,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function fieldValueEquals(string $field, string $value, TraversableElement $container = null)
+    public function fieldValueEquals(string $field, string $value, ?TraversableElement $container = null)
     {
         $node = $this->fieldExists($field, $container);
 
@@ -792,7 +792,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function fieldValueNotEquals(string $field, string $value, TraversableElement $container = null)
+    public function fieldValueNotEquals(string $field, string $value, ?TraversableElement $container = null)
     {
         $node = $this->fieldExists($field, $container);
         $actual = $node->getValue();
@@ -819,7 +819,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function checkboxChecked(string $field, TraversableElement $container = null)
+    public function checkboxChecked(string $field, ?TraversableElement $container = null)
     {
         $node = $this->fieldExists($field, $container);
 
@@ -836,7 +836,7 @@ class WebAssert
      *
      * @throws ExpectationException
      */
-    public function checkboxNotChecked(string $field, TraversableElement $container = null)
+    public function checkboxNotChecked(string $field, ?TraversableElement $container = null)
     {
         $node = $this->fieldExists($field, $container);
 


### PR DESCRIPTION
It will be a blocker for Drupal 11

Links
- https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
- https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated